### PR TITLE
Make the guest tools ISO 'optional'.

### DIFF
--- a/manifest
+++ b/manifest
@@ -3,4 +3,4 @@ dom0 ext3gz required dom0-rootfs.i686.xc.ext3.gz /
 uivm vhdgz required uivm-rootfs.i686.xc.ext3.vhd.gz /storage/uivm
 ndvm vhdgz required ndvm-rootfs.i686.xc.ext3.vhd.gz /storage/ndvm
 syncvm vhdgz required syncvm-rootfs.i686.xc.ext3.vhd.gz /storage/syncvm
-file iso required xc-tools.iso /storage/isos/xc-tools.iso
+file iso optional xc-tools.iso /storage/isos/xc-tools.iso


### PR DESCRIPTION
This should be 'required' as it is currently but since it's not buildable
from the OSS bits yet it should be 'optional' till that's sorted.
