### PR TITLE
[do_build.sh] be less verbose, and don't try to build source-info.json...

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -18,7 +18,7 @@ export HOME
 # make git not complain about user not being set
 export GIT_AUTHOR_NAME="Build user at `hostname`" 
 OE_BUILD_CACHE="$MISC_DIR/oe"
-OE_BB_THREADS=10
+OE_BB_THREADS=9
 BRANCH=master
 export HOME
 BUILD_UID=`id -u`
@@ -810,8 +810,6 @@ set -o pipefail #end of fragile part
 do_repositories()
 {
         (
-                set -x
-
                 local info_dir="$OUTPUT_DIR/$NAME/raw/info"
                 local info="$info_dir/repository"
 
@@ -1066,6 +1064,12 @@ do_sdk()
 
 do_source_info()
 {
+        if [ "$SOURCE" -eq 0 ]
+        then
+                echo "Not generating source info: '-S' option was not specified"
+                return
+        fi
+
         echo "source info:"
         echo "  - copy source info"
 


### PR DESCRIPTION
...when not building the source iso
