### PR TITLE
Make Windows Build Machine from public URLs (step 1)

### DIFF
--- a/windows/mkbuildmachine/config.xml
+++ b/windows/mkbuildmachine/config.xml
@@ -6,23 +6,24 @@
   <LogDir></LogDir>
   <HelperDir></HelperDir>
   <!-- Set these URLs to ones that make sense for you... -->
-  <HelperURL>http://git/cgit.cgi/xenclient/build-scripts.git/plain/windows/mkbuildmachine/</HelperURL>
-  <CygwinSrc>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/cygwin/setup.exe</CygwinSrc>
-  <CygwinMirror>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/cygwin/mirror</CygwinMirror>
-  <NSISSrc>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/nsis/nsis-2.23-setup.exe</NSISSrc>
-  <NSISZip>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/nsis/nsis-2.23-log.zip</NSISZip>
+  <HelperURL>https://raw.githubusercontent.com/OpenXT/openxt/master/windows/mkbuildmachine/</HelperURL>
+  <CygwinSrc>https://www.cygwin.com/setup-x86.exe</CygwinSrc>
+  <CygwinMirror>http://www.mirrorservice.org/sites/sourceware.org/pub/cygwin/</CygwinMirror>
+  <NSISSrc>http://prdownloads.sourceforge.net/nsis/nsis-2.46-setup.exe</NSISSrc>
+  <NSISZip>http://prdownloads.sourceforge.net/nsis/nsis-2.46-log.zip</NSISZip>
   <WinDDK6001>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\WinDDK.6001.18002\unpacked</WinDDK6001>
   <WinDDK701>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\WinDDK.7.1.0\unpacked</WinDDK701>
   <WST>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/WinqualSubmissionTool/WinqualSubmissionTool.msi</WST>
-  <DotNet45>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/visual_studio_2012_P/FrameWorks/dotNetFx45_Full_setup.exe</DotNet45>
-  <SQLSCE32>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/visual_studio_2012_P/packages/SSCE40/SSCERuntime_x86-ENU</SQLSCE32>
-  <SQLSCE64>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/visual_studio_2012_P/packages/SSCE40/SSCERuntime_x64-enu</SQLSCE64>
+  <DotNet45>http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_setup.exe</DotNet45>
+  <SQLSCE32>http://download.microsoft.com/download/0/5/D/05DCCDB5-57E0-4314-A016-874F228A8FAD/SSCERuntime_x86-ENU.exe</SQLSCE32>
+  <SQLSCE64>http://download.microsoft.com/download/0/5/D/05DCCDB5-57E0-4314-A016-874F228A8FAD/SSCERuntime_x64-ENU.exe</SQLSCE64>
   <VS2012P>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\visual_studio_2012_P</VS2012P>
   <SDKWin8>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\SDK_WDK_Win8\SDK</SDKWin8>
   <WDKWin8>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\SDK_WDK_Win8\WDK</WDKWin8>
-  <Wix>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/Wix/wix37.exe</Wix>
-  <CAPICOM>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/capicom.msi</CAPICOM>
-  <VS2012U4>http://www.cam.xci-test.com/xc_dist/winbuild/Version001/VS2012.4.exe</VS2012U4>
+  <Wix>"WixURLisNowHardcodedInInstall-wix.ps1"</Wix>
+  <CAPICOM>http://download.microsoft.com/download/7/7/0/7708ec16-a770-4777-8b85-0fcd05f5ba60/capicom_dc_sdk.msi</CAPICOM>
+  <VS2012U4>http://download.microsoft.com/download/D/4/8/D48D1AC2-A297-4C9E-A9D0-A218E6609F06/VSU4/VS2012.4.exe</VS2012U4>
+  <MSMSrc>\\stove.cam.xci-test.com\xc_dist\winbuild\Version001\visual_studio_2005_MSM\MSM_files\*</MSMSrc>
   <!-- These are the steps taken to create a build machine -->
   <Steps>
     <Step name="cygwin" helper="install-cygwin.ps1">

--- a/windows/mkbuildmachine/install-cygwin.ps1
+++ b/windows/mkbuildmachine/install-cygwin.ps1
@@ -33,5 +33,5 @@ $client.DownloadFile($download, $setup)
 # 5. Overwrite setup.ini and setup.bz2 in the root of the mirror with these new files.
 
 # Piping the output to Write-Host forces the script to wait for Cygwin and gives us nice logs
-& $setup -q -X -O -s $mirror | Write-Host
+& $setup -q -X -O -s $mirror -P "git,zip,unzip" | Write-Host
 

--- a/windows/mkbuildmachine/install-nsis.ps1
+++ b/windows/mkbuildmachine/install-nsis.ps1
@@ -21,8 +21,8 @@ if (!($args.Length -ieq 3))
 }
 
 $folder =    ("{0}\nsis" -f $args[0])
-$setup =     ("{0}\nsis-2.23-setup.exe" -f $folder)
-$zip =       ("{0}\nsis-2.23-log.zip" -f $folder)
+$setup =     ("{0}\nsis-2.46-setup.exe" -f $folder)
+$zip =       ("{0}\nsis-2.46-log.zip" -f $folder)
 $download1 = $args[1]
 $download2 = $args[2]
 

--- a/windows/mkbuildmachine/install-wix.ps1
+++ b/windows/mkbuildmachine/install-wix.ps1
@@ -7,7 +7,7 @@ if (!($args.Length -ieq 2))
 
 $folder = ("{0}\Wix" -f $args[0])
 $setup = ("{0}\wix.exe" -f $folder)
-$download = $args[1]
+$download = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wix&DownloadId=762937&FileTime=130301249344430000&Build=20911"
 
 if ([IO.Directory]::Exists($folder))
 {

--- a/windows/mkbuildmachine/winbuild-setup.ps1
+++ b/windows/mkbuildmachine/winbuild-setup.ps1
@@ -171,7 +171,7 @@ foreach($step in $xmlroot.Steps.ChildNodes)
             if($global:RebootCount -eq 0){
                 if ($step.helper.Length -gt 0)
                 {
-                    $HelperURL = $global:HelperURL + $step.helper + "?h=libre"
+                    $HelperURL = $global:HelperURL + $step.helper
                     log-info -info ("Downloading helper: " + $HelperURL)
 
                     #Download the helper file

--- a/windows/winbuild-prepare.ps1
+++ b/windows/winbuild-prepare.ps1
@@ -257,7 +257,8 @@ function check-platform()
     $tmparr = @(0..1)
     $tmparr[0] = (Get-ItemProperty $nsiskey VersionMajor).VersionMajor
     $tmparr[1] = (Get-ItemProperty $nsiskey VersionMinor).VersionMinor
-    if (($tmparr[0] -ne 2) -or ($tmparr[1] -ne 23))
+    # NSIS Check we are running grater than 2.23
+    if (($tmparr[0] -ne 2) -or ($tmparr[1] -lt 23))
     {
         throw ("NSIS invalid version - major: " + $tmparr[0] + " minor: " + $tmparr[1])
     }


### PR DESCRIPTION
This change is the first result of the effort to install
all tools needed to build OpenXT windows components using
public URLs.
- Update Helper URL
- Remove libre branch tag
- Update Cygwin URL
- Update nsis URL (2.46 now) and Check we are using >= than 2.23
- Update capicom URL
- Add MSMSrc patch
- update dotNetFx45_Full_setup.exe URL
- Update SQLSCE32 and SQLSCE64 URLs
- Update VS2012U4 URL
- Update Wix URL

Wix URL is now hardcoded in install-wix.ps1 (This is needed because
if we put this URL in the config file the XML parser fails because
of the &, so embedding the URL here is a workaround for the problem)
