### PR TITLE
winbuild-installer.ps1: Remove proxy nullifier

### DIFF
--- a/windows/BuildSupport/winbuild-installer.ps1
+++ b/windows/BuildSupport/winbuild-installer.ps1
@@ -6,7 +6,6 @@ $dotNetURL = $argtable["dotNetURL"]
 
 #Set up web client to download stuff
 [System.Net.WebClient] $wclient = New-Object System.Net.WebClient
-$wclient.Proxy = $null
 
 # Create directory to store bootstrapper packages
 new-item -ItemType directory -Path ".\msi-installer\bootstrapper\packages" -Force


### PR DESCRIPTION
Removed line that nullifies system proxy. Not sure why this was there, but can do builds on open internet and behind proxy without this.
