### PR TITLE
improve error handling, logging and incremental behaviour in Windows bui...

### DIFF
--- a/windows/BuildSupport/checked-copy.psm1
+++ b/windows/BuildSupport/checked-copy.psm1
@@ -1,0 +1,6 @@
+function Checked-Copy($src, $dest) {
+    copy $src -destination $dest -Force -V
+    if (-Not $?) {
+        throw "Unable to copy $src to $dest"
+    }
+}

--- a/windows/BuildSupport/invoke.psm1
+++ b/windows/BuildSupport/invoke.psm1
@@ -1,0 +1,27 @@
+# TODO: this is pasted from xc-windows.git/do_build.ps1 but I would like to find a way
+# to share code. For now if you fix a bug here please fix it in that version
+# as well.
+
+# run a command with output redirection so that we wait
+# and check the error code and fail if non-zero
+function Invoke-CommandChecked {
+  Write-Host ("Invoke "+([string]$args))
+  $description = $args[0]
+  $command = $args[1]
+  # doing "& *args" now would be good if it didn't take all the arguments and turn 
+  # it into a string and try and run that. We need to specify the command name separately.
+  # we cannot remove items from arrays
+  # see http://technet.microsoft.com/en-us/library/ee692802.aspx
+  # so we turn the args into an arraylist instead
+  $arglist = New-Object System.Collections.ArrayList
+  $arglist.AddRange($args)
+  # ... then remove the first two argument
+  $arglist.RemoveRange(0,2)
+  Write-Host ("+$command "+[string]$arglist)
+  & $command $arglist | Out-Host
+  Write-Host "$command exited with code $LastExitCode"
+  if ($LastExitCode -ne 0) {
+      throw "failed $description; $command exited with code $LastExitCode"
+  }
+}
+

--- a/windows/BuildSupport/winbuild-utils.ps1
+++ b/windows/BuildSupport/winbuild-utils.ps1
@@ -93,10 +93,11 @@ function parse-version-string([string]$strver)
              $result[0].Groups[4].Value)
 }
 
+# Now we use Start-Transcript for logging we don't need this but keep it 
+# for now until all the calls have been replaced with Write-Host commands
 function log-info([string]$info)
 {
     Write-Host $info
-    Add-Content -Path $global:logfile -Value $info
 }
 
 function log-script-end()
@@ -113,10 +114,11 @@ function log-info-wrap([string]$info)
 	log-info -info "--------------------------------------------------------"
 }
 
+# Now we use Start-Transcript for logging we don't need this but keep it 
+# for now until all the calls have been replaced with Write-Host commands
 function log-error([string]$err)
 {
     Write-Host $err
-    Add-Content -Path $global:logfile -Value ("ERROR: " + $err)
 }
 
 function execute-log-and-out([string]$command)
@@ -124,7 +126,6 @@ function execute-log-and-out([string]$command)
        $out = Invoke-Expression $command #Do the command
        #Write-Host $out #To stdout
        $out | Foreach-Object {$_.ToString()} | Write-Host
-       $out | Foreach-Object {$_.ToString()} | Out-File $global:logfile -Append -Encoding ASCII #To Log
                
 }
 
@@ -156,8 +157,11 @@ function common-init([string]$cmdinv)
     {
         New-Item -Path $global:logdir -Type Directory -Force
     }
-    $global:logfile = $global:logdir + "\" + $cmdinv + ".log"
-
+    $ts = get-date -uformat "%Y-%m-%d-%H%M%S"
+    $global:logfile = $global:logdir + "\" + $cmdinv + "_"+ $ts +".log"
+    Write-Host "Logging to [$global:logfile]"
+    Start-Transcript $global:logfile
+    Write-Host "Logging started to [$global:logfile]"
     # Trace out a basic log header
     log-info -info "--------------------------------------------------------"
     log-info -info ("Windows Build Log - " + (Get-Date))

--- a/windows/config/sample-config.xml
+++ b/windows/config/sample-config.xml
@@ -6,10 +6,12 @@
   <DdkDir>C:\WinDDK\7600.16385.1</DdkDir>
   <VSDir>"C:\Program Files\Microsoft Visual Studio 11.0"</VSDir>
   <MSBuild>C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe</MSBuild>
+  <GitBin>C:\Program Files\Git\bin\git.exe</GitBin>
   <GitUrl>git://github.com/OpenXT</GitUrl>
   <dotNetURL>http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe</dotNetURL>
   <DefaultEula>True</DefaultEula>
   <CertName>Put Your Cert Name Here</CertName>
+  <!-- if you want to cross sign put the path of a cross signing certificate here in a CrossSign node-->
   <CompanyName>Put Your Company Name Here</CompanyName>
   <SignTool>"C:\Program Files\Windows Kits\8.0\bin\x86"</SignTool>
 
@@ -47,6 +49,8 @@
           <Param>BuildBranch</Param>
           <Param>MSBuild</Param>
           <Param>GitUrl</Param>
+          <Param>GitBin</Param>	  
+          <Param>CrossSign</Param>
         </Parameters>
       </Run>
     </Step>

--- a/windows/winbuild-all.ps1
+++ b/windows/winbuild-all.ps1
@@ -7,21 +7,7 @@
 $mywd = Split-Path -Parent $MyInvocation.MyCommand.Path
 $root = ([System.IO.Directory]::GetCurrentDirectory())
 . ($mywd + "\BuildSupport\winbuild-utils.ps1")
-
-#Function to execute a git's command and log the output (Only really a function to make the script a bit neater)
-function execute-git-and-log([string]$command,[string]$parameters, [string]$logfile)
-{
-    # Trace out a basic log header
-    log-info -info "--------------------------------------------------------"
-    log-info -info ("Windows Build Log - " + (Get-Date))
-    log-info -info ("Executing " + $command + " " + $parameters)
-    log-info -info ("Working Dir: " + $global:builddir)
-    log-info -info ("Logging To:  " + $global:logdir + "\" + $logfile + ".log")
-    log-info -info "--------------------------------------------------------"
-    # Execute the command and tee output to the log directory
-    $logdir = read-config-value -config $global:cfgfile -name "LogDir"
-    & $command ($parameters) | Foreach-Object {$_.ToString()} | Tee-Object (".\" + $logdir + "\" + $logfile + ".log")
-}
+Import-Module $mywd\BuildSupport\invoke.psm1
 
 $cmdinv = $MyInvocation.MyCommand.Name
 
@@ -37,6 +23,16 @@ if (!(Test-Path -Path $cfgfile -PathType Leaf))
 {
     Write-Host "ERROR: Config file not present - config:" $cfgfile
     return $false
+}
+
+$gitbin = read-config-value -config $global:cfgfile -name "GitBin"
+if ($gitbin.Length -lt 1) {
+    log-error -err "Failed to read GitBin value from config"
+    ExitWithCode -exitcode $global:failure
+}
+if (-Not (Test-Path $gitbin)) {
+    log-error -err "Git binary at $gitbin not found"
+    ExitWithCode -exitcode $global:failure
 }
 
 #Get the git URL from config & BuildTag
@@ -57,89 +53,122 @@ $branch = read-config-value -config $global:cfgfile -name "BuildBranch"
 # Parse the config to determine how to run the build
 foreach($step in $xmlroot.Steps.ChildNodes)
 {
+
     # Filter out comment nodes
-    if ($step.name.CompareTo('#comment') -ne 0)
-    {
-        # Treat this step as one that needs a git clone if the config specifies it
-        if ($step.clone.CompareTo('false') -ne 0)
-        {
-            # If a local reference repo exists, use that for the clone to speed things up
-            if(Test-Path -Path ("../../reference/" + $step.name +  ".reference")){
-                $gitsrc = $giturl + "/" + $step.name +  ".git"
-                $gitdst = $global:builddir + "\" + $step.name
-                log-info -info ("Cloning: " + $gitsrc + " To: " + $gitdst + " via reference repo")
-                execute-log-and-out -command ("git clone -n --reference " + ("../../reference/" + $step.name +  ".reference") + " " + $gitsrc + " 2>&1")
-            }else{
-                $gitsrc = $giturl + "/" + $step.name +  ".git"
-                $gitdst = $global:builddir + "\" + $step.name
-                log-info -info ("Cloning: " + $gitsrc + " To: " + $gitdst)
-                execute-log-and-out -command ("git clone -n " + $gitsrc + " 2>&1")
-            }
-
-            # Check everything went okay
-            if($LastExitCode -ne $global:success)
-            {
-                log-error -err ("Failed to properly clone git repo: " + $gitsrc)
-                ExitWithCode -exitcode $global:failure
-            }
-            
-            # If a branch has been specified in the config, checkout HEAD of that branch over tag info
-            if ($branch.Length -gt 0)
-            {
-                Push-Location -Path $step.name
-                log-info -info ("Checking out: " + $branch + " For: " + $step.name)
-                Invoke-Expression ("git fetch origin 2>&1") #Do checkout
-                if ($branch.CompareTo("master") -eq 0) {
-                    Invoke-Expression ("git checkout -q $branch 2>&1") #Do checkout
-                } else {
-                    Invoke-Expression ("git checkout -q origin/$branch -b $branch 2>&1") #Do checkout
-                    #If error, just do a checkout defaulted to master
-                    if($?){
-                        Invoke-Expression ("git checkout -q -b $branch 2>&1") #Do checkout
-                    }
-                }
-                
-                Pop-Location
-            }elseif ($tag.Length -gt 0)
-            {
-                Push-Location -Path $step.name
-                log-info -info ("Checking out: " + $tag + " For: " + $step.name)
-                Invoke-Expression ("git checkout -q -b " + $tag + " " + $tag + " 2>&1") #Do checkout
-                Pop-Location
-            }
-        }
-
-        # Check that we want to run the command for this step (Helps reduce build tests during development)
-        if($step.Run.execute -ne $null -and $step.Run.execute.CompareTo("false") -ne 0)
-        {
-            # Make certain there is a command to run
-            if ($step.Run.Command.Length -gt 0)
-            {
-                $parameters = $null
-                # Create parameters string
-                if($step.Run.Parameters -ne $null)
-                {
-                    foreach($param in $step.Run.Parameters.ChildNodes)
-                    {
-                        $parameter = $param.'#text'
-                        $value = read-config-value -config $cfgfile -name $parameter
-                        #Check parameter value is not empty
-                        if($value.Length -ne 0){
-                          $parameters = $parameters + $parameter + "='" + $value + "' "
-                        }
-                    }
-                }
-                
-                # Now we're all done parsing this step, execute the associated command and wait for it to return
-                execute-git-and-log -command $step.Run.Command -parameters ("& '" + $root + "\" + $step.Run.Path + "' " + $parameters) -logfile $step.name
-                if($LastExitCode -ne $global:success)
-                {
-                    log-info -info ("Failed trying to execute " + $step.Run.Command + " " + ($root + "\" + $step.Run.Path)) 
-                    ExitWithCode $global:failure
-                }
-            }
-        }
+    if ($step.name.CompareTo('#comment') -eq 0) {
+         Write-Host "skipping comment node"
+         continue
+     }
+   
+    # Treat this step as one that needs a git clone if the config specifies it
+    if ($step.clone.CompareTo('false') -ne 0) {
+         $doclone = $true
+         $gitdst = $global:builddir + "\" + $step.name
+         # skip the clone if it has already been done
+         if (Test-Path ($step.name+"\.git")) {
+             $nfiles = (Get-ChildItem $gitdst).Count
+             # it is possible a failure during an earlier clone resulted in a directory,
+             # possibly with a .git subdirectory, so if we see that we still need to clone
+             if ([int]$nfiles -gt 1) {
+                 $doclone = $false
+             }
+         }
+    } else {
+         $doclone = $false
     }
+
+    if ($doclone) {
+       $gitsrc = $giturl + "/" + $step.name +  ".git"
+       # If a local reference repo exists, use that for the clone to speed things up
+       if(Test-Path -Path ("../../reference/" + $step.name +  ".reference")){
+           Write-Host "Cloning: " + $gitsrc + " To: " + $gitdst + " via reference repo"
+           & $gitbin clone -n --reference ("../../reference/" + $step.name +  ".reference") $gitsrc  | Out-Host
+       }else{
+           Write-Host "Cloning:" $gitsrc  " To: "  $gitdst
+           & $gitbin clone -n $gitsrc | Out-Host
+       }
+
+       # Check everything went okay
+       if($LastExitCode -ne $global:success)
+       {
+           throw "unable to clone "+$gitsrc+" exit code $LastExitCode"
+       }
+       
+       # If a branch has been specified in the config, checkout HEAD of that branch over tag info
+       if ($branch.Length -gt 0)
+       {
+           Push-Location -Path $step.name
+           log-info -info ("Checking out: " + $branch + " For: " + $step.name)
+	   & $gitbin fetch origin | Out-Host
+	   if ($LastExitCode -ne 0) {
+               throw "unable to fetch in $step.name"
+           }
+           if ($branch.CompareTo("master") -eq 0) {
+               & $gitbin checkout -q $branch | Out-Host
+           } else {
+               & $gitbin checkout -q origin/$branch -b $branch | Out-Host
+               #If error, just do a checkout defaulted to master
+               if($LastExitCode -ne 0){
+		    & gitbin checkout -q -b $branch | Out-Host
+               }
+           }
+           
+           Pop-Location
+       }elseif ($tag.Length -gt 0)
+       {
+           Push-Location -Path $step.name
+           Write-Host ("Checking out: " + $tag + " For: " + $step.name)
+		& $gitbin checkout -q -b $tag $tag | Out-Host
+		if ($LastExitCode -ne 0) {
+		    throw "unable to checkout tag $tag for $step.name"
+           }
+           Pop-Location
+       } else {
+	        throw "Need either tag or branch"
+       }
+   }
+
+   # Check that we want to run the command for this step (Helps reduce build tests during development)
+   if($step.Run.execute -eq $null) {
+       Write-Host ("Execute not specified in "+([string]$step.Name))
+       continue
+   }
+   if ($step.Run.execute.CompareTo("false") -eq 0)
+   {
+       Write-Host ("Execute set to false in "+([string]$step.Name))
+       continue
+   }
+   # Make certain there is a command to run
+   if ($step.Run.Command.Length -eq 0) { 
+       Write-Host ("No command in "+[string]($step.Name))
+       continue
+   }		
+   # Create parameters array
+   $parameters = @($root + "\"+$step.Run.Path)
+   if($step.Run.Parameters -ne $null) {
+        foreach($param in $step.Run.Parameters.ChildNodes) {
+            $parameter = $param.'#text'
+            $value = read-config-value -config $cfgfile -name $parameter
+            #Check parameter value is not empty
+            if($value.Length -ne 0){
+                 $parameters += ("'"+$parameter + "=" + $value+"'")
+            }
+        }
+   }
+           
+   # Now we're all done parsing this step, execute the associated command and wait for it to return
+   $command = [string] ($step.Run.command)
+   $stepName = [string] ($step.Name)
+   Write-Host ""
+   Write-Host "-----------------------------------------------------------------"
+   Write-Host ("Executing $stepName command $command with parameters $parameters at "+(Get-Date))
+   Invoke-CommandChecked "Executing step $stepName" $command $parameters 
+   Write-Host ""
+   Write-Host "================================================================="
+   Write-Host ("Execution of $stepName command $command with parameters $parameters finished at "+(Get-Date)+" code $LastExitCode")
+   if($LastExitCode -ne 0) {
+        throw "Failed trying to execute $stepName command " + $command + " " + ($root + "\" + $step.Run.Path) + " code $LastExitCode"
+   }
 }
 
 log-info -info  ("Completed " + $cmdinv)

--- a/windows/winbuild-prepare.ps1
+++ b/windows/winbuild-prepare.ps1
@@ -246,8 +246,6 @@ function check-platform()
     $cygver = & uname -r
     Write-Output ("Found CYGWIN version: $cygver rootdir: $cygdir ...")
 
-    try-command -command "git"
-    Write-Output "Found GIT command ..."
 
     try-command -command "unzip"
     Write-Output "Found UNZIP command ..."
@@ -458,11 +456,6 @@ function winbuild-main([string]$cmdinv, $argtable)
     # Do a platform sanity check
     check-platform
 
-    #Output the contents of the newly generated config file
-    Write-Output ("Contents of newly generated config file:`n" + $global:cfgfile)
-    $readConfig = Get-Content $global:cfgfile
-    $readConfig = ([string]::Join([Environment]::NewLine, $readConfig))
-    Write-Output $readConfig
 }
 
 #########################################################


### PR DESCRIPTION
...ld

Check for failures in many cases and exit immediately.

If git checkout (and clone) operations have already been done do not
repeat them. With this change it is now possible to re-run
winbuild-all.ps1 without deleting a lot of files and directories
first.

Use Start-Transcript for logging, meaning that (close to) all
the build output goes to logs\winbuild-all.ps_(timestamp).log, with
less code than we needed before.

Pass git binary to xc-windows (it does its own clone and checkout
of xc-vusb) from config rather than assume it is on the path.

Rearrange some if statement trees to flatten out some logic
to make it easier to follow.

Add library modules to run commands and copy with error checking,
used in this code and by my versions of some of the windows XT repositories.

Add crosssign parameter to control code signing.
