### PR TITLE
[OXT-23] Move local build config to openxt.git and use build/ as TOPDIR ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 misc/*
-build/*
+build/bitbake.lock
+build/conf/local.conf
+build/conf/sanity_info
+build/local.settings
+build/manifest
+build/oe
+build/oeenv
+build/pseudodone
+build/repos
+build/tmp-eglibc
 build-output/*

--- a/build/bb
+++ b/build/bb
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright (c) 2012 Citrix Systems, Inc.
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+BDIR=`readlink -f \`dirname $0\``
+REPOS="$BDIR/repos"
+
+export BB_ENV_EXTRAWHITE="MACHINE BUILD_UID"
+PATH="$REPOS/bitbake/bin:$PATH"
+
+# allow to disble OE wrapper script
+if [ "x$1" = "x--disable-wrapper" ];then
+    shift
+else
+    PATH="$REPOS/openembedded-core/scripts:$PATH"
+fi
+export PATH
+
+exec bitbake "$@"

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -1,0 +1,17 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "4"
+
+BBFILES ?= ""
+BBLAYERS ?= " \
+  ${TOPDIR}/repos/extra \
+  ${TOPDIR}/oe/xenclient \
+  ${TOPDIR}/repos/openembedded-core/meta \
+  ${TOPDIR}/repos/meta-openembedded/meta-xfce \
+  ${TOPDIR}/repos/meta-openembedded/meta-oe \
+  ${TOPDIR}/repos/meta-openembedded/meta-gnome \
+  ${TOPDIR}/repos/meta-java \
+  ${TOPDIR}/repos/meta-selinux \
+  "
+
+ 

--- a/setup_build
+++ b/setup_build
@@ -99,7 +99,7 @@ if [ "$1" != "env" ]; then
   mkdir -p $REPOS || die "Could not create local build dir"
 
   getgit $REPOS/bitbake $BITBAKE_REPO $BITBAKE_TAG
-  for p in `pwd`/patches/bitbake/*.patch; do
+  for p in `pwd`/oe/patches/bitbake/*.patch; do
       if [ ! -f "$p.APPLIED" ]; then
         echo "Applying BitBake patch: $p"
 	pushd $REPOS/bitbake
@@ -117,12 +117,12 @@ if [ "$1" != "env" ]; then
   fi
 fi
 
-if [ ! -e $OE_XENCLIENT_DIR/xenclient/conf/local.conf ]; then
-  ln -s $OE_XENCLIENT_DIR/xenclient/conf/local.conf-dist \
-      $OE_XENCLIENT_DIR/xenclient/conf/local.conf
+if [ ! -e $OE_XENCLIENT_DIR/conf/local.conf ]; then
+  ln -s $OE_XENCLIENT_DIR/conf/local.conf-dist \
+      $OE_XENCLIENT_DIR/conf/local.conf
 fi
 
-BBPATH=$OE_XENCLIENT_DIR/xenclient:$REPOS/openembedded:$OE_XENCLIENT_DIR/oe-addons
+BBPATH=$OE_XENCLIENT_DIR/oe/xenclient:$REPOS/openembedded:$OE_XENCLIENT_DIR/oe-addons
 if [ ! -z "$EXTRA_DIR" ]; then
   BBPATH=$REPOS/$EXTRA_DIR:$BBPATH
 fi


### PR DESCRIPTION
...for the OXT OE build.

This commit moves the local build metadata out of the xenclient-oe.git repo
and into the openxxt.git repo. These things aren't typically part of a meta
layer so if we're turning xenclient-oe.git into a meta layer then these need
a new home in openxt.git. Further minor edits to these files have been made
so that the build TOPDIR is build/ instead of build/oe/.

bb: Move the helper script 'bb' from xenclient-oe.git to the the openxt.git
    build directory.
bblayers.conf: Move the main 'conf' directory and the bblayers.conf file from
    xenclient-oe.git to openxt.git.
do_build.sh: Fixup paths to find the new location of the build output and
    configuration.
.gitignore: Be a bit more specific about ignored build
    files.
