### PR TITLE
OXT-92 Move TOPDIR of xenclinet-oe repo.

### DIFF
--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -4,7 +4,7 @@ LCONF_VERSION = "4"
 
 BBFILES ?= ""
 BBLAYERS ?= " \
-  ${TOPDIR}/repos/xenclient-oe/xenclient \
+  ${TOPDIR}/repos/xenclient-oe \
   ${TOPDIR}/repos/extra \
   ${TOPDIR}/repos/openembedded-core/meta \
   ${TOPDIR}/repos/meta-openembedded/meta-xfce \


### PR DESCRIPTION
This must be paired with the corresponding re-organization of the xenclient-oe meta layer: https://github.com/OpenXT/xenclient-oe/pull/53

The real work to move TOPDIR happens there but the bblayers.conf (changed here) needs to be moved as well.
