### PR TITLE
Remove arbitrary 'ID - 110000' math from tools version string

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -1426,7 +1426,7 @@ get_version()
 
         if [ "$ID" ] ; then
                 # Build number is a 16-bit unsigned integer in Windows
-                XC_TOOLS_BUILD=$(((ID - 110000) % 65536))
+                XC_TOOLS_BUILD=$((${ID} % 65536))
         else
                 XC_TOOLS_BUILD=0
         fi


### PR DESCRIPTION
Seems to be cruft from old XenClient days. If using low numbers as ID, this would result in negative numbers in the version string.