### PR TITLE
Change mirror in example to mirror.openxt.org

### DIFF
--- a/example-config
+++ b/example-config
@@ -9,7 +9,7 @@ OPENXT_GIT_PROTOCOL="git"
 OE_GIT_MIRROR=
 
 # Downloads needed for OpenXT build. Optionally replace with a local mirror.
-OPENXT_MIRROR="http://openxt.xci-test.com/mirror"
+OPENXT_MIRROR="http://mirror.openxt.org"
 
 # Used to construct build name.
 NAME_SITE="openxt"


### PR DESCRIPTION
Since it was created and is more readily maintained, use the
mirror.openxt.org site.

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>