### PR TITLE
Remove dependency on sync-wui build

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -1372,6 +1372,11 @@ do_syncui()
     local file="$OUTPUT_DIR/$NAME/raw/$name"
     local out="$OUTPUT_DIR/$NAME/sync"
 
+    if [ ! -r "${file}" ]; then
+      echo "syncui: Not built, skipping"
+      return 0 
+    fi
+
     echo "syncui:"
     echo "  - copy $name"
 


### PR DESCRIPTION
Client doesn't rely on sync-wui, so build should not fail if this wasn't
built.

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>