### PR TITLE
[OXT-105] Fix Windows Build certificate signing issues

### DIFF
--- a/windows/config/sample-config.xml
+++ b/windows/config/sample-config.xml
@@ -63,6 +63,7 @@
           <Param>CertName</Param>
           <Param>MSBuild</Param>
           <Param>CompanyName</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>
@@ -89,6 +90,7 @@
           <Param>BuildType</Param>
           <Param>CertName</Param>
           <Param>VerString</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>

--- a/windows/config/sample-config.xml
+++ b/windows/config/sample-config.xml
@@ -81,6 +81,7 @@
           <Param>VerString</Param>
           <Param>CertName</Param>
           <Param>CompanyName</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>


### PR DESCRIPTION
Jira ticket OXT-105, needed to add parameters to sample-config.xml to be passed on to build scripts.