### PR TITLE
[OXT-105] Added parameters which get passed down to powershell scripts for signtool.

### DIFF
--- a/windows/config/sample-config.xml
+++ b/windows/config/sample-config.xml
@@ -63,6 +63,7 @@
           <Param>CertName</Param>
           <Param>MSBuild</Param>
           <Param>CompanyName</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>
@@ -80,6 +81,7 @@
           <Param>VerString</Param>
           <Param>CertName</Param>
           <Param>CompanyName</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>
@@ -89,6 +91,7 @@
           <Param>BuildType</Param>
           <Param>CertName</Param>
           <Param>VerString</Param>
+          <Param>SignTool</Param>
         </Parameters>
       </Run>
     </Step>


### PR DESCRIPTION
Added signtool path parameter to initial sample-config.xml to be passed on
to powershell scripts.  The installer was failing to get signed correctly because of this.