### PR TITLE
Revert "Merge pull request #56 from brendank310/xen-4.3.4-pullreq"

### DIFF
--- a/common-config
+++ b/common-config
@@ -1,5 +1,5 @@
 # xen version and source archive
-XEN_VERSION="4.3.4"
-XEN_SRC_URI="http://bits.xensource.com/oss-xen/release/4.3.4/xen-4.3.4.tar.gz"
-XEN_SRC_MD5SUM="127ae10ce832a3547e171d2653caa1fa"
-XEN_SRC_SHA256SUM="307d1197f4be9ac9bf78b2cdb97bb77bee8ca4589749b6d5ee3dddbd59e8186e"
+XEN_VERSION="4.3.3"
+XEN_SRC_URI="http://bits.xensource.com/oss-xen/release/4.3.3/xen-4.3.3.tar.gz"
+XEN_SRC_MD5SUM="1b4438a50d8875700ac2c7e1ffbcd91b"
+XEN_SRC_SHA256SUM="59eb0e1c4a1f66965fe56dcf27cdb5872bf7e0585b7f2e60bd7967ec7f744ebf"


### PR DESCRIPTION
This reverts commit af55352248d2c8c1aec91ea50fe35f6510b0364f, reversing
changes made to 6e29ff7e30d5a25d748a5df38c631b744a19aa33.

Xen 4.3.4 causes significant instability and should be reverted to 4.3.3 for now.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>