### PR TITLE
Broadwell ACM/SINIT Integration

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -903,7 +903,7 @@ do_updates()
         done
 }
 
-ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm"
+ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm bdw.acm"
 
 extract_acms()
 {


### PR DESCRIPTION
Added shorthand ACM for Broadwell (bdw) to list

OXT-126

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>