### PR TITLE
manifest: make syncvm optional, as OpenXT should run just fine without it

### DIFF
--- a/manifest
+++ b/manifest
@@ -2,5 +2,5 @@ control tarbz2 required control.tar.bz2 /
 dom0 ext3gz required dom0-rootfs.i686.xc.ext3.gz /
 uivm vhdgz required uivm-rootfs.i686.xc.ext3.vhd.gz /storage/uivm
 ndvm vhdgz required ndvm-rootfs.i686.xc.ext3.vhd.gz /storage/ndvm
-syncvm vhdgz required syncvm-rootfs.i686.xc.ext3.vhd.gz /storage/syncvm
+syncvm vhdgz optional syncvm-rootfs.i686.xc.ext3.vhd.gz /storage/syncvm
 file iso optional xc-tools.iso /storage/isos/xc-tools.iso


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>