### PR TITLE
Add .config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/repos
 build/sstate-cache
 build/tmp-eglibc
 build-output/*
+.config


### PR DESCRIPTION
Ensures config doesn't sneak into commits, and also prevents accidental
deletion via 'git clean'

Signed-off-by: Kevin Pearson <kevin.pearson.4@us.af.mil>