### PR TITLE
Jethro merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ build/oe
 build/oeenv
 build/pseudodone
 build/repos
+build/cache
 build/sstate-cache
-build/tmp-eglibc
+build/tmp-glibc
 build-output/*
 .config

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -1,7 +1,8 @@
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
-LCONF_VERSION = "4"
+LCONF_VERSION = "6"
 
+BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 BBLAYERS ?= " \
   ${TOPDIR}/repos/xenclient-oe \
@@ -9,6 +10,8 @@ BBLAYERS ?= " \
   ${TOPDIR}/repos/meta-openembedded/meta-xfce \
   ${TOPDIR}/repos/meta-openembedded/meta-oe \
   ${TOPDIR}/repos/meta-openembedded/meta-gnome \
+  ${TOPDIR}/repos/meta-openembedded/meta-networking \
+  ${TOPDIR}/repos/meta-openembedded/meta-python \
   ${TOPDIR}/repos/meta-java \
   ${TOPDIR}/repos/meta-selinux \
   "

--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -13,8 +13,6 @@ USER_CLASSES = "buildstats"
 PATCHRESOLVE = "noop"
 CONF_VERSION = "1"
 TMPDIR ?= "${TOPDIR}/build"
-#DL_DIR ?= "${TOPDIR}/downloads"
-#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
 
 STAGING_IDLDIR = "${STAGING_DATADIR}/idl"
 
@@ -22,7 +20,7 @@ ENABLE_BINARY_LOCALE_GENERATION = "1"
 LOCALE_UTF8_ONLY = "1"
 
 # ocaml
-SYSROOT_OCAML_PATH = "${STAGING_DIR_NATIVE}${libdir_native}/${TUNE_PKGARCH}${TARGET_VENDOR}-${TARGET_OS}/ocaml"
+SYSROOT_OCAML_PATH = "${STAGING_DIR_NATIVE}${libdir_native}/${TRANSLATED_TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}/ocaml"
 OCAML_STDLIBDIR = "${SYSROOT_OCAML_PATH}/site-lib"
 OCAML_HEADERS = "${SYSROOT_OCAML_PATH}"
 export ocamllibdir = "${libdir}/ocaml"
@@ -97,7 +95,6 @@ VIRTUAL-RUNTIME_keymaps = "xenclient-console-keymaps"
 
 FILESYSTEM_PERMS_TABLES = "files/xc-fs-perms.txt"
 POLKITAUTH = ""
-BBMASK = "busybox_1.19"
 
 # prevent tasks from creating empty "${S}" dir
 do_clean[dirs] = "${WORKDIR}"

--- a/example-config
+++ b/example-config
@@ -1,5 +1,8 @@
-# Branch to build.
+# OpenXT branch to build.
 BRANCH="master"
+
+# OpenXT branch to build.
+OE_BRANCH="jethro"
 
 # OpenXT git repositories. Optionally replace with a local mirror.
 OPENXT_GIT_MIRROR="github.com/OpenXT"
@@ -7,6 +10,21 @@ OPENXT_GIT_PROTOCOL="git"
 
 # Optional mirror of upstream OpenEmbedded git repositories.
 OE_GIT_MIRROR=
+
+# Bitbake version to checkout
+BB_BRANCH="1.28"
+
+# These are best set via this or local.settings instead of being set in the script itself.
+BITBAKE_REPO=git://git.openembedded.org/bitbake.git
+OE_CORE_REPO=git://git.openembedded.org/openembedded-core
+META_OE_REPO=git://git.openembedded.org/meta-openembedded
+META_JAVA_REPO=git://git.yoctoproject.org/meta-java
+META_SELINUX_REPO=git://git.yoctoproject.org/meta-selinux
+
+# Use the lines below out to override checking out the branch matching the OE release
+# The commit hash for meta-java is the last commit that had openjdk6 and idedtea6
+META_JAVA_TAG=a73939323984fca1e919d3408d3301ccdbceac9c
+#META_SELINUX_TAG="dizzy"
 
 # Downloads needed for OpenXT build. Optionally replace with a local mirror.
 OPENXT_MIRROR="http://mirror.openxt.org"

--- a/setup_build-next.sh
+++ b/setup_build-next.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# OpenXT git repo setup file.
+
+#######################################################################
+# checkout_git_branch                                                 #
+# param1: Path to the git repo                                        #
+# param2: Preferred branch to checkout.  Fallback will be to master.  #
+#                                                                     #
+# Checks out the branch specified in param2 for the repo located at   #
+# the file path in param1.  If the branch is not part of the git repo #
+# the master branch is checked out instead.                           #
+#######################################################################
+checkout_git_branch() {
+	local path="$1"
+	local branch="$2"
+
+	cd $path
+	git checkout "$branch" 2>/dev/null|| git checkout -b "$branch" origin/$branch 2>/dev/null || { echo "The value $branch does not exist as a branch or HEAD position. Falling back to the master branch."; git checkout master 2>/dev/null; }
+	cd $OLDPWD
+}
+
+#######################################################################
+# fetch_git_repo                                                      #
+# param1: Path (absolute) to place the repo                           #
+# param2: Git url to fetch                                            #
+#                                                                     #
+# Fetches the repo specified by param2 into the directory specified   #
+# by param1.                                                          #
+#######################################################################
+fetch_git_repo() {
+	local path="$1"
+	local repo="$2"
+
+	echo "Fetching $repo..."
+	set +e
+	git clone -n $repo "$path" || die "Clone of git repo failed: $repo"
+	set -e
+}
+
+#######################################################################
+# update_git_repo                                                     #
+# param1: Path to the git repo                                        #
+#                                                                     #
+# Updates the repo located at the path specified by param1.  All      #
+# branches will be updated.                                           #
+#######################################################################
+update_git_repo() {
+	local path="$1"
+	local repo="$2"
+
+	echo "Updating local copy of $repo..."
+	cd $path
+	set +e
+	#  Simple pull only works if fast forware is possible.
+	git pull || die "Update of git repo failed: $path  Please resolve manually."
+	cd $OLDPWD
+}
+
+process_git_repo() {
+	local path="$1"
+	local repo="$2"
+	local branch="$3"
+
+	if [ -d $path ]; then
+		# The destination for the repo already exists.
+		if [ -d $path/.git ]; then
+			# And it is already a git repo!
+			cd $path
+			set +e
+			local existing=$(git config --get remote.origin.url)
+			set -e
+			cd $OLDPWD
+			if [ "$existing" = "$repo" ]; then
+				# Always checkout the branch again in case the user specified another one.
+				checkout_git_branch $path $branch
+				# The repo has already been pulled before.  Update it.
+				update_git_repo $path $repo
+			else
+				# Whatever is here it is not what we want.
+				echo "Found an unexpected repo at $path.  Replacing with $repo."
+				rm -rf $path
+				fetch_git_repo $path $repo $branch
+				# Always checkout the branch again in case the user specified another one.
+				checkout_git_branch $path $branch
+			fi
+		else
+			# The folder as already there but not a git repo.  Blow it away.
+			echo "Path $path exists but is not a git repo.  Replacing with $repo."
+			cd $OLDPWD
+			rm -rf $path
+			fetch_git_repo $path $repo $branch
+			# Always checkout the branch again in case the user specified another one.
+			checkout_git_branch $path $branch
+		fi
+	else
+		# The path does not exist.  Proceed.
+		fetch_git_repo $path $repo $branch
+		# Always checkout the branch again in case the user specified another one.
+		checkout_git_branch $path $branch
+	fi
+}
+
+OE_XENCLIENT_DIR=`pwd`
+REPOS=$OE_XENCLIENT_DIR/repos
+OE_PARENT_DIR=$(dirname $OE_XENCLIENT_DIR)
+
+# Load our config
+[ -f "$OE_PARENT_DIR/.config" ] && . "$OE_PARENT_DIR/.config"
+
+[ -f "$OE_XENCLIENT_DIR/local.settings" ] && . "$OE_XENCLIENT_DIR/local.settings"
+
+mkdir -p $REPOS || die "Could not create local build dir"
+
+# Pull down the OpenXT repos
+process_git_repo $REPOS/xenclient-oe $XENCLIENT_REPO $XENCLIENT_TAG
+process_git_repo $REPOS/bitbake $BITBAKE_REPO $BB_BRANCH
+process_git_repo $REPOS/openembedded-core $OE_CORE_REPO $OE_BRANCH
+process_git_repo $REPOS/meta-openembedded $META_OE_REPO $OE_BRANCH
+if [ ! -z ${META_JAVA_TAG+x} ]; then
+	process_git_repo $REPOS/meta-java $META_JAVA_REPO $META_JAVA_TAG
+else
+	process_git_repo $REPOS/meta-java $META_JAVA_REPO $OE_BRANCH
+fi
+if [ ! -z ${META_SELINUX_TAG+x} ]; then
+	process_git_repo $REPOS/meta-selinux $META_SELINUX_REPO $META_SELINUX_TAG
+else
+	process_git_repo $REPOS/meta-selinux $META_SELINUX_REPO $OE_BRANCH
+fi
+
+if [ ! -e $OE_XENCLIENT_DIR/conf/local.conf ]; then
+  ln -s $OE_XENCLIENT_DIR/conf/local.conf-dist \
+      $OE_XENCLIENT_DIR/conf/local.conf
+fi
+
+BBPATH=$OE_XENCLIENT_DIR/oe/xenclient:$REPOS/openembedded:$OE_XENCLIENT_DIR/oe-addons
+if [ ! -z "$EXTRA_DIR" ]; then
+  BBPATH=$REPOS/$EXTRA_DIR:$BBPATH
+fi
+
+cat > oeenv <<EOF 
+OE_XENCLIENT_DIR=$OE_XENCLIENT_DIR
+PATH=$OE_XENCLIENT_DIR/repos/bitbake/bin:\$PATH
+BBPATH=$BBPATH
+BB_ENV_EXTRAWHITE="OE_XENCLIENT_DIR MACHINE GIT_AUTHOR_NAME EMAIL"
+
+export OE_XENCLIENT_DIR PATH BBPATH BB_ENV_EXTRAWHITE
+EOF


### PR DESCRIPTION
These changes are for building the xenclient-oe repo against the current OE Jethro (2.0) release.  Make sure to use a new or updated build host/container.  See  https://openxt.atlassian.net/wiki/display/BS/Jessie+systemd+container for instructions on creating a new Jessie systemd container.