### PR TITLE
Drop usage of gene3fs.

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -37,44 +37,32 @@ IMAGE_DEPENDS_ext3.vhd = "hs-vhd-native genext2fs-native e2fsprogs-native"
 IMAGE_CMD_raw = "cp -a ${IMAGE_ROOTFS} ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.raw"
 
 IMAGE_CMD_xc.ext3 = "( set -x; \
+	${IMAGE_CMD_ext3}; \
+	I0=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.ext3; \
 	I=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.xc.ext3; \
-	TGT_SIZE=`expr ${ROOTFS_SIZE} \* 1024`; \
-	truncate -s ${TGT_SIZE} $I; \
-	mke2fs -F -t ext3 $I; \
+	mv $I0 $I; \
 	tune2fs -c -1 -i 0 $I; \
-	gene3fs -i $I -d ${IMAGE_ROOTFS}; \
 	e2fsck -f -y $I || true)"
-IMAGE_DEPENDS_xc.ext3 = "gene3fs-native e2fsprogs-native"
+IMAGE_DEPENDS_xc.ext3 = "e2fsprogs-native"
 
 # sadly the vhd stack in XC doesn't seem to [yet] understand libbudgetvhd's vhds
 # take rootfs size in KB, convert to bytes for truncate size, convert to MB
 # and deal with bash rounding. If odd after rounding, add 1, if even, add 2 since we lost
 # some precision; vhd size must also be a multiple of 2 MB.
 IMAGE_CMD_xc.ext3.vhd = "( set -x; \
+	${IMAGE_CMD_ext3}; \
+	I0=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.ext3; \
 	I=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.xc.ext3.vhd; \
-	TGT_SIZE=`expr ${ROOTFS_SIZE} \* 1024`; \
 	TGT_VHD_SIZE=`expr ${ROOTFS_SIZE} / 1024`; \
 	if [ `expr ${TGT_VHD_SIZE} % 2` -eq 1 ]; \
 		then TGT_VHD_SIZE=`expr ${TGT_VHD_SIZE} + 1`; \
 	else TGT_VHD_SIZE=`expr ${TGT_VHD_SIZE} + 2`; \
 	fi; \
-	truncate -s ${TGT_SIZE} $I.tmp; \
-	mke2fs -F -t ext3 $I.tmp; \
-	tune2fs -c -1 -i 0 $I.tmp; \
-	gene3fs -i $I.tmp -d ${IMAGE_ROOTFS}; \
-	e2fsck -f -y $I.tmp || true ; \
-	vhd convert $I.tmp $I ${TGT_VHD_SIZE} ; \
-	rm -f $I.tmp  )"
-IMAGE_DEPENDS_xc.ext3.vhd = "hs-vhd-native gene3fs-native e2fsprogs-native"
-
-IMAGE_CMD_xc.ext3.bvhd = "( set -x ; \
-	I=${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.xc.ext3.bvhd; \
-	bvhd_create $I ${ROOTFS_SIZE}; \
-	mke2fs -Z -F -t ext3 $I; \
-	tune2fs -Z -c -1 -i 0 $I; \
-	gene3fs -V -i $I -d ${IMAGE_ROOTFS}; \
-	e2fsck -Z -f -y $I || true )"
-IMAGE_DEPENDS_xc.ext3.bvhd = "gene3fs-native e2fsprogs-native"
+	tune2fs -c -1 -i 0 $I0; \
+	e2fsck -f -y $I0 || true ; \
+	vhd convert $I0 $I ${TGT_VHD_SIZE} ; \
+	rm -f $I0  )"
+IMAGE_DEPENDS_xc.ext3.vhd = "hs-vhd-native e2fsprogs-native"
 
 # Build source packages if XENCLIENT_BUILD_SRC_PACKAGES is set to 1.
 INHERIT += "xenclient-src-package"


### PR DESCRIPTION
The problem is that there are a small number of unlabeled files in the final
image produced by gene3fs, whereas building the filesystem images using the
normal tools does not exhibit this problem.  It turns out that these are
cases where there were multiple hard links to a single file (e.g. e2fsck,
fsck.ext2, fsck.ext3, fsck.ext4).  In the pseudo files database, only one of
the instances is getting its attribute recorded, and in the filesystem image
that is generated by gene3fs, multiple hard links to the same inode are not
being preserved; multiple separate inodes are being created and the other
instances are never getting an xattr set.  In contrast, mkfs.ext3 preserves
the hard links as links and correctly labels the inode.

In the old pseudo xattr patch in openxt, xattrs were fetched by device,
inode, and xattr name, so queries on the same inode will yield the same
result.  In the upstream pseudo xattr implementation, it looks like they
are fetching by file id and xattr name, where file ids are keys into the
files table, which includes pathname information in addition to device
and inode.  So it seems that a getxattr on any of the hard links that did
not have setxattr() called on it will fail.  And setfiles won't bother
relabeling a file if it already has the right label, so it won't call setxattr
on more than one of the hard links.

Arguably the upstream pseudo xattr implementation is buggy, but it appears
to follow the same model as for other attributes and it "works" when using
the upstream image creation tools, so it doesn't seem likely that they would
be interested in a "fix" there.

Before:
12867 system_u:object_r:unlabeled_t:s0 /sbin/e2fsck
12799 system_u:object_r:fsadm_exec_t:s0 /sbin/fsck.ext2
12861 system_u:object_r:unlabeled_t:s0 /sbin/fsck.ext3
12882 system_u:object_r:unlabeled_t:s0 /sbin/fsck.ext4
12801 system_u:object_r:unlabeled_t:s0 /sbin/fsck.ext4dev
(All separate inodes, and only one of them is labeled)

After:
11774 system_u:object_r:fsadm_exec_t:s0 /sbin/e2fsck
11774 system_u:object_r:fsadm_exec_t:s0 /sbin/fsck.ext2
11774 system_u:object_r:fsadm_exec_t:s0 /sbin/fsck.ext3
11774 system_u:object_r:fsadm_exec_t:s0 /sbin/fsck.ext4
11774 system_u:object_r:fsadm_exec_t:s0 /sbin/fsck.ext4dev
(All hard links to a single inode, which is labeled)

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>