### PR TITLE
Clone meta-selinux at known good rev.

### DIFF
--- a/example-config
+++ b/example-config
@@ -24,7 +24,13 @@ META_SELINUX_REPO=git://git.yoctoproject.org/meta-selinux
 # Use the lines below out to override checking out the branch matching the OE release
 # The commit hash for meta-java is the last commit that had openjdk6 and idedtea6
 META_JAVA_TAG=a73939323984fca1e919d3408d3301ccdbceac9c
-#META_SELINUX_TAG="dizzy"
+
+# WORK-AROUND: Compatible meta-selinux rev.
+# Later commits will eventually conflict with oe-core jethro branch.
+# Known conflicts are:
+# - findutils_4.6.%.bbappend
+# - e2fsprogs_git.bbappend
+META_SELINUX_TAG=2188d5b09b8f79cce935890ad814b0afafa09b9c
 
 # Downloads needed for OpenXT build. Optionally replace with a local mirror.
 OPENXT_MIRROR="http://mirror.openxt.org"


### PR DESCRIPTION
Using meta-selinux branch master as of this day will conflict with
oe-core jethro branch:
ERROR: No recipes available for
meta-selinux/recipes-extended/findutils/findutils_4.6.%.bbappend
meta-selinux/recipes-devtools/e2fsprogs/e2fsprogs_git.bbappend

Propositions to manage multiple layers configuration are already
discussed. Until that is done, resort to pick a fixed, compatible, rev.
