### PR TITLE
Custom build username and easy ssh

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -43,7 +43,7 @@ SUBNET_PREFIX="192.168"
 
 # -- End of script configuration settings.
 
-
+CONTAINER_USER=%CONTAINER_USER%
 BUILD_USER="$(whoami)"
 BUILD_USER_ID="$(id -u ${BUILD_USER})"
 BUILD_USER_HOME="$(eval echo ~${BUILD_USER})"
@@ -114,7 +114,7 @@ build_container() {
     # then we also ssh it until it's up, using the ping as a "sleep 1"
     tries=0
     until ping -c 1 -w 1 ${CONTAINER_IP} >/dev/null 2>&1 && \
-          ssh -i "${BUILD_USER_HOME}"/ssh-key/openxt build@${CONTAINER_IP} \
+          ssh -i "${BUILD_USER_HOME}"/ssh-key/openxt ${CONTAINER_USER}@${CONTAINER_IP} \
               -oStrictHostKeyChecking=no true >/dev/null 2>&1; do
        tries=$(( tries + 1 ))
        if [ $tries -ge 30 ]; then
@@ -137,7 +137,7 @@ build_container() {
             -e "s|\%BRANCH\%|${BRANCH}|" \
             -e "s|\%ALL_BUILDS_SUBDIR_NAME\%|${ALL_BUILDS_SUBDIR_NAME}|" |\
         ssh -t -t -i "${BUILD_USER_HOME}"/ssh-key/openxt \
-            -oStrictHostKeyChecking=no build@${CONTAINER_IP}
+            -oStrictHostKeyChecking=no ${CONTAINER_USER}@${CONTAINER_IP}
 }
 
 build_container "01" "oe"

--- a/build-scripts/centos/setup.sh
+++ b/build-scripts/centos/setup.sh
@@ -20,6 +20,8 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
+CONTAINER_USER=%CONTAINER_USER%
+
 # Remove the root password
 passwd -d root
 
@@ -40,11 +42,11 @@ for kernelpath in `ls -d /usr/src/kernels/*`; do
 done
 
 # Add a build user
-adduser build
-mkdir -p /home/build/.ssh
-touch /home/build/.ssh/authorized_keys
-ssh-keygen -N "" -t dsa -C build@openxt-centos -f /home/build/.ssh/id_dsa
-chown -R build:build /home/build/.ssh
+adduser ${CONTAINER_USER}
+mkdir -p /home/${CONTAINER_USER}/.ssh
+touch /home/${CONTAINER_USER}/.ssh/authorized_keys
+ssh-keygen -N "" -t dsa -C ${CONTAINER_USER}@openxt-centos -f /home/${CONTAINER_USER}/.ssh/id_dsa
+chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.ssh
 
 # Make the user a passwordless sudoer, as dkms unfortunately needs to run as root
-echo "build   ALL=(ALL)       NOPASSWD:ALL" >> /etc/sudoers
+echo "${CONTAINER_USER}   ALL=(ALL)       NOPASSWD:ALL" >> /etc/sudoers

--- a/build-scripts/debian/setup.sh
+++ b/build-scripts/debian/setup.sh
@@ -21,6 +21,7 @@
 #
 
 MIRROR=%MIRROR%
+CONTAINER_USER=%CONTAINER_USER%
 
 # Remove the root password
 passwd -d root
@@ -33,11 +34,11 @@ apt-get update
 apt-get -y install $PKGS </dev/null
 
 # Add a build user
-adduser --disabled-password --gecos "" build
-mkdir -p /home/build/.ssh
-touch /home/build/.ssh/authorized_keys
-ssh-keygen -N "" -t dsa -C build@openxt-debian -f /home/build/.ssh/id_dsa
-chown -R build:build /home/build/.ssh
+adduser --disabled-password --gecos "" ${CONTAINER_USER}
+mkdir -p /home/${CONTAINER_USER}/.ssh
+touch /home/${CONTAINER_USER}/.ssh/authorized_keys
+ssh-keygen -N "" -t dsa -C ${CONTAINER_USER}@openxt-debian -f /home/${CONTAINER_USER}/.ssh/id_dsa
+chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.ssh
 
 # Setup sbuild
 INCLUDE="build-essential,dh-make,dkms" # Packages needed by chroots to build stuffs
@@ -51,4 +52,4 @@ sbuild-createchroot jessie /home/chroots/jessie-amd64 $MIRROR --arch=amd64 --inc
 # In that case, it seems to be OK to run them after.
 # See https://wiki.debian.org/sbuild
 sbuild-update --keygen
-sbuild-adduser build
+sbuild-adduser ${CONTAINER_USER}

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -29,6 +29,10 @@ BRANCH=%BRANCH%
 SUBNET_PREFIX=%SUBNET_PREFIX%
 ALL_BUILDS_SUBDIR_NAME=%ALL_BUILDS_SUBDIR_NAME%
 
+cd ~/certs
+CERTS_PATH=`pwd`
+cd ..
+
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
@@ -44,10 +48,10 @@ if [ ! -e .config ] ; then
 BRANCH="${BRANCH}"
 OPENXT_GIT_MIRROR="${SUBNET_PREFIX}.${IP_C}.1/${BUILD_USER}"
 OPENXT_GIT_PROTOCOL="git"
-REPO_PROD_CACERT="/home/build/certs/prod-cacert.pem"
-REPO_DEV_CACERT="/home/build/certs/dev-cacert.pem"
-REPO_DEV_SIGNING_CERT="/home/build/certs/dev-cacert.pem"
-REPO_DEV_SIGNING_KEY="/home/build/certs/dev-cakey.pem"
+REPO_PROD_CACERT="${CERTS_PATH}/prod-cacert.pem"
+REPO_DEV_CACERT="${CERTS_PATH}/dev-cacert.pem"
+REPO_DEV_SIGNING_CERT="${CERTS_PATH}/dev-cacert.pem"
+REPO_DEV_SIGNING_KEY="${CERTS_PATH}/dev-cakey.pem"
 EOF
 fi
 

--- a/build-scripts/oe/setup.sh
+++ b/build-scripts/oe/setup.sh
@@ -22,6 +22,8 @@
 
 # This scripts sets up the OE container for OpenXT
 
+CONTAINER_USER=%CONTAINER_USER%
+
 # Remove root password
 passwd -d root
 
@@ -64,18 +66,18 @@ echo '/bin/uname.real $@ | sed "s/amd64/i686/g" | sed "s/x86_64/i686/g"' >> /bin
 chmod +x /bin/uname
 
 # Add a build user
-adduser --disabled-password --gecos "" build
-mkdir -p /home/build/.ssh
-touch /home/build/.ssh/authorized_keys
-ssh-keygen -N "" -t dsa -C build@openxt-oe -f /home/build/.ssh/id_dsa
-chown -R build:build /home/build/.ssh
-echo "export MACHINE=xenclient-dom0" >> /home/build/.bashrc
-chown build:build /home/build/.bashrc
+adduser --disabled-password --gecos "" ${CONTAINER_USER}
+mkdir -p /home/${CONTAINER_USER}/.ssh
+touch /home/${CONTAINER_USER}/.ssh/authorized_keys
+ssh-keygen -N "" -t dsa -C ${CONTAINER_USER}@openxt-oe -f /home/${CONTAINER_USER}/.ssh/id_dsa
+chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.ssh
+echo "export MACHINE=xenclient-dom0" >> /home/${CONTAINER_USER}/.bashrc
+chown ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.bashrc
 
 # Create build certs
-mkdir /home/build/certs
-openssl genrsa -out /home/build/certs/prod-cakey.pem 2048
-openssl genrsa -out /home/build/certs/dev-cakey.pem 2048
-openssl req -new -x509 -key /home/build/certs/prod-cakey.pem -out /home/build/certs/prod-cacert.pem -days 1095 -subj "/C=US/ST=Massachusetts/L=Boston/O=OpenXT/OU=OpenXT/CN=openxt.org"
-openssl req -new -x509 -key /home/build/certs/dev-cakey.pem -out /home/build/certs/dev-cacert.pem -days 1095 -subj "/C=US/ST=Massachusetts/L=Boston/O=OpenXT/OU=OpenXT/CN=openxt.org"
-chown -R build:build /home/build/certs
+mkdir /home/${CONTAINER_USER}/certs
+openssl genrsa -out /home/${CONTAINER_USER}/certs/prod-cakey.pem 2048
+openssl genrsa -out /home/${CONTAINER_USER}/certs/dev-cakey.pem 2048
+openssl req -new -x509 -key /home/${CONTAINER_USER}/certs/prod-cakey.pem -out /home/${CONTAINER_USER}/certs/prod-cacert.pem -days 1095 -subj "/C=US/ST=Massachusetts/L=Boston/O=OpenXT/OU=OpenXT/CN=openxt.org"
+openssl req -new -x509 -key /home/${CONTAINER_USER}/certs/dev-cakey.pem -out /home/${CONTAINER_USER}/certs/dev-cacert.pem -days 1095 -subj "/C=US/ST=Massachusetts/L=Boston/O=OpenXT/OU=OpenXT/CN=openxt.org"
+chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/certs

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -265,5 +265,6 @@ if [ ! -d /home/git/${BUILD_USER} ]; then
 fi
 
 cp -f build.sh "${BUILD_USER_HOME}/"
+sed -i "s/\%CONTAINER_USER\%/${CONTAINER_USER}/" ${BUILD_USER_HOME}/build.sh
 chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/build.sh
 echo "Done! Now login as ${BUILD_USER} and run ~/build.sh to start a build."

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -83,15 +83,31 @@ if [ ! `cut -d ":" -f 1 /etc/passwd | grep "^${BUILD_USER}$"` ]; then
     mkdir -p "${BUILD_USER_HOME}/.ssh"
     touch "${BUILD_USER_HOME}"/.ssh/authorized_keys
     touch "${BUILD_USER_HOME}"/.ssh/known_hosts
+    touch "${BUILD_USER_HOME}"/.ssh/config
     chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh
     echo "${BUILD_USER}  ALL=(ALL:ALL) ALL" >> /etc/sudoers
 else
+    # The user exists, check and verbosely fix missing configuration bits
     BUILD_USER_HOME="$(eval echo ~${BUILD_USER})"
+    if [ ! -d "${BUILD_USER_HOME}"/.ssh ]; then
+        echo "${BUILD_USER} has no SSH directory, creating one."
+        mkdir -p "${BUILD_USER_HOME}"/.ssh
+        chown ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh
+    fi
     if [ ! -f "${BUILD_USER_HOME}"/.ssh/authorized_keys ]; then
         echo "${BUILD_USER} has no SSH authorized_keys file, creating one."
-        mkdir -p "${BUILD_USER_HOME}"/.ssh
         touch "${BUILD_USER_HOME}"/.ssh/authorized_keys
-        chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh
+        chown ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh/authorized_keys
+    fi
+    if [ ! -f "${BUILD_USER_HOME}"/.ssh/known_hosts ]; then
+        echo "${BUILD_USER} has no SSH known_hosts file, creating one."
+        touch "${BUILD_USER_HOME}"/.ssh/known_hosts
+        chown ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh/known_hosts
+    fi
+    if [ ! -f "${BUILD_USER_HOME}"/.ssh/config ]; then
+        echo "${BUILD_USER} has no SSH config file, creating one."
+        touch "${BUILD_USER_HOME}"/.ssh/config
+        chown ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/.ssh/config
     fi
     grep ${BUILD_USER} /etc/sudoers >/dev/null 2>&1 || {
         echo "${BUILD_USER} is not a sudoer, adding him."


### PR DESCRIPTION
These commits allow the name of the build user to be configured, and adds lines to the ssh configuration to make things simpler for the user (example: `ssh oe` will take you to the oe container)