### PR TITLE
build-scripts: make the main ssh key a dsa one

### DIFF
--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -118,7 +118,7 @@ fi
 # Create an SSH key for the user, to communicate with the containers
 if [ ! -d "${BUILD_USER_HOME}"/ssh-key ]; then
     mkdir "${BUILD_USER_HOME}"/ssh-key
-    ssh-keygen -N "" -f "${BUILD_USER_HOME}"/ssh-key/openxt
+    ssh-keygen -N "" -t dsa -f "${BUILD_USER_HOME}"/ssh-key/openxt
     chown -R ${BUILD_USER}:${BUILD_USER} "${BUILD_USER_HOME}"/ssh-key
 fi
 


### PR DESCRIPTION
Because that's what the other scripts do.

Signed-off-by: Jed <lejosnej@ainfosec.com>