### PR TITLE
Remove OpenXT specific OE tasks

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -71,9 +71,6 @@ INHERIT += "xenclient-src-package"
 # set to 1.
 INHERIT += "xenclient-src-info"
 
-# OpenXT specific OE tasks
-INHERIT += "xenclient-customtask"
-
 # 2) Build tweaks/hacks
 
 PREFERRED_PROVIDER_console-tools = "console-tools"


### PR DESCRIPTION
Those tasks are deprecated, see related PR: https://github.com/OpenXT/xenclient-oe/pull/239
