### PR TITLE
windows: mkbuildmachine: remove CAPICOM and trailing whitespace

### DIFF
--- a/windows/PackageLibrary.psm1
+++ b/windows/PackageLibrary.psm1
@@ -6,8 +6,11 @@ param (
 # we need to make a list of packages available
 # I don't know how to export a list to callers directly so simply return
 # the list of packages as a string array
+# Note: this list used to include "CAPICOM" (between "Wix" and "WDK8")
+#     The URL for CAPICOM is broken, Microsoft probably dropped support for it.
+#     CAPICOM doesn't seem to be needed anyway, so it was removed from the list.
 function Get-Packages {
-  return "GnuPG","Cygwin","NSIS","NSISAdvancedLogging","7Zip","DotNet45","WinDDK710","SqlSce32", "SqlSce64", "VS2012", "Win8SDK", "Wix", "CAPICOM", "WDK8", "VS2012U4", "PathAdditions"
+  return "GnuPG","Cygwin","NSIS","NSISAdvancedLogging","7Zip","DotNet45","WinDDK710","SqlSce32", "SqlSce64", "VS2012", "Win8SDK", "Wix", "WDK8", "VS2012U4", "PathAdditions"
 }
 
 # powershell inspects to import only installed modules

--- a/windows/PackageLibrary.psm1
+++ b/windows/PackageLibrary.psm1
@@ -24,7 +24,7 @@ Import-Module $ScriptDir\PerformDownload.psm1
 function Invoke-CommandChecked {
   Write-Host "+$args"
   $command = $args[0]
-  # doing "& *args" now would be good if it didn't take all the arguments and turn 
+  # doing "& *args" now would be good if it didn't take all the arguments and turn
   # it into a string and try and run that. We need to specify the command name separately.
   # we cannot remove items from arrays
   # see http://technet.microsoft.com/en-us/library/ee692802.aspx
@@ -44,13 +44,13 @@ function Invoke-CommandChecked {
 }
 
 function Get-RedirectedUrl {
- 
+
     $url = "http://wix.codeplex.com/downloads/get/762937"
- 
+
     $request = [System.Net.WebRequest]::Create($url)
     $request.AllowAutoRedirect=$false
     $response=$request.GetResponse()
- 
+
     If ($response.StatusCode -eq "Found")
     {
         $response.GetResponseHeader("Location")
@@ -91,8 +91,8 @@ Function Install-NSISAdvancedLogging () {
   $name = $nsisVersion + "-log.zip"
   $zip_fullname = $env:temp+'\'+$name
   PerformDownload "$nsisBaseUrl/$name" $zip_fullname "B1-BA-3B-81-E2-1F-88-F9-7D-A0-D0-76-91-6B-FF-25-88-44-07-70-0B-04-51-9C-7B-D1-5E-6D-49-6F-F4-25"
-  # Pile of pain to unzip using built in unzipper 
-  # Pass it the zip file and destination before running copyhere    
+  # Pile of pain to unzip using built in unzipper
+  # Pass it the zip file and destination before running copyhere
   # 0x14 is a combination of:
   #     0x10 - overwrite existing files
   #     0x4  - hide windows dialog box
@@ -125,7 +125,7 @@ function Install-Cygwin {
   cd $env:temp
   $cygwinsetup = $env:temp + "\setup-x86.exe"
   PerformDownloadGpg "https://www.cygwin.com/setup-x86.exe" $cygwinsetup "https://cygwin.com/key/pubring.asc" "https://cygwin.com/setup-x86.exe.sig"
-  # Ideally we would like to run the cygwin installer with something like the following package list:   
+  # Ideally we would like to run the cygwin installer with something like the following package list:
   #  -P "vim,git,rsync,zip,unzip,libiconv,guilt,openssh"
   # Unfortunately doing this with the -q silent option does not work. The workaround is to do the following:
   # 1. Add the -X option to the command line below, disabling validation of setup.ini
@@ -134,7 +134,7 @@ function Install-Cygwin {
   # 4. Make a copy of setup as setup.ini and bzip2 the new setup back to setup.bz2.
   # 5. Overwrite setup.ini and setup.bz2 in the root of the mirror with these new files.
 
-  # NOTE:  Looks like the issue above might have been due to picking a mirror and resolved by 
+  # NOTE:  Looks like the issue above might have been due to picking a mirror and resolved by
   #        -O and -s below.  Need to make sure git, zip, and unzip are the only packages needed.
   Invoke-CommandChecked $cygwinsetup -q -X -O -s http://www.mirrorservice.org/sites/sourceware.org/pub/cygwin/ -P "git,zip,unzip,mkisofs" | Write-Host
 }
@@ -149,7 +149,7 @@ function Install-7zip {
   Invoke-CommandChecked msiexec /i $szsetup /q
 }
 
-function Test-DotNet45 {  
+function Test-DotNet45 {
   if (-Not (Test-Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full')) {
     return $false
   }
@@ -161,7 +161,7 @@ function Test-DotNet45 {
 function Install-DotNet45 {
   $dnsetup = $env:temp + "\dotnet45.exe"
   PerformDownload "http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe" $dnsetup "6C-2C-58-91-32-E8-30-A1-85-C5-F4-0F-82-04-2B-EE-30-22-E7-21-A2-16-68-0B-D9-B3-99-5B-A8-6F-37-81"
-  Invoke-CommandChecked $dnsetup /passive /norestart 
+  Invoke-CommandChecked $dnsetup /passive /norestart
 }
 
 function Test-WinDDK710 {
@@ -199,7 +199,7 @@ function Install-WDK8 {
   PerformDownload "http://download.microsoft.com/download/2/4/C/24CA7FB3-FF2E-4DB5-BA52-62A4399A4601/wdk/wdksetup.exe" $exe "83-35-88-1E-40-20-DE-B6-ED-4C-E3-5C-CC-8E-EC-A0-E6-83-66-E6-B7-4C-E1-8F-A1-42-E2-92-0E-DD-34-CE"
   Invoke-CommandChecked $exe /q /norestart
   # ideally I'd like find out how to detect whether the coinstaller is installed separately to the wdksetup, and handle the
-  # coinstaller as a separate package. 
+  # coinstaller as a separate package.
   PerformDownload "http://download.microsoft.com/download/0/5/F/05FD6919-6250-425B-86ED-9B095E54065A/wdfcoinstaller.msi" $msi "29-31-42-07-81-4C-E9-D5-D7-36-95-F7-E9-23-95-39-CF-37-C7-9E-75-0B-9D-5E-A5-A5-EF-54-87-A5-83-D6"
   Invoke-CommandChecked msiexec.exe /i $msi /qn
 }
@@ -212,7 +212,7 @@ function Test-PathAdditions {
     }
   }
   return $true
-}  
+}
 
 function Install-PathAdditions {
   $curpath = [Environment]::GetEnvironmentVariable("Path")
@@ -243,7 +243,7 @@ function Test-SqlSce32 {
 function Install-SqlSce32 {
   $ssce32 = $env:temp+'\SSCERuntime_x86-ENU.exe'
   PerformDownload "http://download.microsoft.com/download/0/5/D/05DCCDB5-57E0-4314-A016-874F228A8FAD/SSCERuntime_x86-ENU.exe" $ssce32 "0C-1E-76-83-EC-B6-4C-A9-1E-6C-74-C5-D3-35-FC-B0-EC-33-DB-AF-F2-05-4D-F3-F1-F4-1C-7F-51-D6-17-FF"
-  Invoke-CommandChecked $ssce32 /package /passive 
+  Invoke-CommandChecked $ssce32 /package /passive
   Write-Host "Please reboot your machine now then rerun this script. Otherwise the Visual Studio 2012 install will probably fail."
   Exit
 }
@@ -258,7 +258,7 @@ function Test-SqlSce64 {
 function Install-SqlSce64 {
   $ssce64 = $env:temp+'\SSCERuntime_x64-ENU.exe'
   PerformDownload "http://download.microsoft.com/download/0/5/D/05DCCDB5-57E0-4314-A016-874F228A8FAD/SSCERuntime_x64-ENU.exe" $ssce64 "96-70-F4-B3-BD-59-C2-06-52-A0-25-9B-92-E4-2E-8F-3E-A8-48-6C-11-39-B6-4D-63-61-A4-17-9E-77-49-65"
-  Invoke-CommandChecked $ssce64 /package /passive 
+  Invoke-CommandChecked $ssce64 /package /passive
   Write-Host "Please reboot your machine now then rerun this script. Otherwise the Visual Studio 2012 install will probably fail."
   Exit
 }
@@ -287,7 +287,7 @@ function Test-Win8SDK {
   } else {
     $regPath = "HKLM:\Software\Microsoft\Microsoft SDKs\Windows\v8.0a"
   }
-  $sdkVersionObject = Get-ItemProperty $regPath -Name "ProductVersion" -ErrorAction SilentlyContinue   
+  $sdkVersionObject = Get-ItemProperty $regPath -Name "ProductVersion" -ErrorAction SilentlyContinue
   $sdkVersion = [version]$sdkVersionObject.ProductVersion
   return ($sdkVersion -ge [version]"8.0.50709")
 }
@@ -309,7 +309,7 @@ function Install-Wix {
   $wix = $env:temp +'\wix.exe'
   echo Get-RedirectedUrl
   PerformDownload 'http://wix.codeplex.com/downloads/get/762937' $wixhtml
-  
+
   #Test if file exists.
   if (Test-Path $wixhtml){
     #Parse Wix page.
@@ -319,7 +319,7 @@ function Install-Wix {
         $start = $page.indexOf("Build=")+6
         $end = $page.indexOf('" alt="WiX&#32;Toolset"')
         $build = $page.substring($start, $end - $start)
-        
+
         #Download using build number.
         PerformDownload "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wix&DownloadId=762937&FileTime=130301249344430000&Build=$build" $wix
         Invoke-CommandChecked $wix -passive
@@ -340,8 +340,8 @@ function Install-CAPICOM {
   $capicom = $env:temp+'\capicom.msi'
   $dll = $programFiles32+"\Microsoft CAPICOM 2.1.0.2 SDK\Lib\X86\capicom.dll"
   PerformDownload "http://download.microsoft.com/download/7/7/0/7708ec16-a770-4777-8b85-0fcd05f5ba60/capicom_dc_sdk.msi" $capicom
-  Invoke-CommandChecked msiexec.exe /i $capicom /qn 
-  Invoke-CommandChecked regsvr32 $dll /s 
+  Invoke-CommandChecked msiexec.exe /i $capicom /qn
+  Invoke-CommandChecked regsvr32 $dll /s
 }
 
 function Test-VS2012U4 {
@@ -355,7 +355,7 @@ function Test-VS2012U4 {
     $regPath = "HKLM:\Software\Microsoft\DevDiv\vc\Servicing\11.0\CompilerCore"
   }
 
-  $vsVersionObject = Get-ItemProperty $regPath -Name "Version" -ErrorAction SilentlyContinue   
+  $vsVersionObject = Get-ItemProperty $regPath -Name "Version" -ErrorAction SilentlyContinue
   $vsVersion = [version]$vsVersionObject.Version
   return $vsVersion -ge [version]"11.0.61030"
 }

--- a/windows/PerformDownload.psm1
+++ b/windows/PerformDownload.psm1
@@ -24,41 +24,41 @@ Function PerformDownloadGeneric ($url, $targetFile) {
     # Create the request and do our best to avoid any local caching or socket reusing (causes backend caching)
     # Core of this code is by Jason Niver's blog.
     # http://blogs.msdn.com/b/jasonn/archive/2008/06/13/downloading-files-from-the-internet-in-powershell-with-progress.aspx
-    $uri = New-Object "System.Uri" "$url" 
-    $request = [System.Net.HttpWebRequest]::Create($uri) 
+    $uri = New-Object "System.Uri" "$url"
+    $request = [System.Net.HttpWebRequest]::Create($uri)
     $request.CachePolicy = New-Object System.Net.Cache.HttpRequestCachePolicy([System.Net.Cache.HttpRequestCacheLevel]::NoCacheNoStore)
     $request.Headers.Add("Cache-Control", "no-cache")
     $request.KeepAlive = 0
-    $request.set_Timeout($timeout) 
+    $request.set_Timeout($timeout)
     $tmp1 = $request.RequestUri
     $tmp2 = $request.Timeout
 
-    # Make the actual request 
+    # Make the actual request
     try {
       $response = $request.GetResponse()
-      # Get the file size, allowing the pretty progress bar 
-      $totalLength = [System.Math]::Floor($response.get_ContentLength()/1024) 
+      # Get the file size, allowing the pretty progress bar
+      $totalLength = [System.Math]::Floor($response.get_ContentLength()/1024)
       Write-Host "Total length is $totalLength KiB."
-    
+
       # Set up the buffer for reading the file and writing it to disk
-      $responseStream = $response.GetResponseStream() 
-      $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $targetFile, Create 
-      $buffer = new-object byte[] 10KB 
-      $count = $responseStream.Read($buffer,0,$buffer.length) 
-      $downloadedBytes = $count 
+      $responseStream = $response.GetResponseStream()
+      $targetStream = New-Object -TypeName System.IO.FileStream -ArgumentList $targetFile, Create
+      $buffer = new-object byte[] 10KB
+      $count = $responseStream.Read($buffer,0,$buffer.length)
+      $downloadedBytes = $count
 
       # Download the file and write to disk
-      while ($count -gt 0) 
-      {  
-        $targetStream.Write($buffer, 0, $count) 
-        $count = $responseStream.Read($buffer,0,$buffer.length) 
-        $downloadedBytes = $downloadedBytes + $count 
+      while ($count -gt 0)
+      {
+        $targetStream.Write($buffer, 0, $count)
+        $count = $responseStream.Read($buffer,0,$buffer.length)
+        $downloadedBytes = $downloadedBytes + $count
         Write-Progress -activity "Downloading file '$($url.split('/') | Select -Last 1)'" -status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes/1024)) / $totalLength)  * 100)
-      } 
+      }
       # Clean up after ourselves
       $targetStream.Flush()
-      $targetStream.Close() 
-      $targetStream.Dispose() 
+      $targetStream.Close()
+      $targetStream.Dispose()
       $responseStream.Dispose()
     } catch {
        Write-Host "Unable to download $url error " $_.Exception.Message


### PR DESCRIPTION
CAPICOM was most likely needed only for Windows XP build machines.
The link is broken and I got a successful build without it.