### PR TITLE
windows build daemon: add startup scripts

### DIFF
--- a/windows/BuildDaemon/winbuildd.bat
+++ b/windows/BuildDaemon/winbuildd.bat
@@ -1,0 +1,2 @@
+cd C:\winbuildd
+powershell .\winbuildd.ps1

--- a/windows/BuildDaemon/winbuildd.ps1
+++ b/windows/BuildDaemon/winbuildd.ps1
@@ -1,0 +1,1 @@
+Start-Process "python" "winbuildd.py -c winbuild.cfg -s BOSTON" -Verb runAs


### PR DESCRIPTION
winbuildd.bat goes to the startup folder
winbuildd.ps1 is used by winbuildd.bat to start the daemon as Administrator

OXT-507

Signed-off-by: Jed <lejosnej@ainfosec.com>