### PR TITLE
Allow meta-selinux to follow the jethro branch.

### DIFF
--- a/example-config
+++ b/example-config
@@ -25,12 +25,9 @@ META_SELINUX_REPO=git://git.yoctoproject.org/meta-selinux
 # The commit hash for meta-java is the last commit that had openjdk6 and idedtea6
 META_JAVA_TAG=a73939323984fca1e919d3408d3301ccdbceac9c
 
-# WORK-AROUND: Compatible meta-selinux rev.
-# Later commits will eventually conflict with oe-core jethro branch.
-# Known conflicts are:
-# - findutils_4.6.%.bbappend
-# - e2fsprogs_git.bbappend
-META_SELINUX_TAG=2188d5b09b8f79cce935890ad814b0afafa09b9c
+# Default to the same branch of meta-selinux as OE_BRANCH (e.g. jethro).
+# Uncomment and edit if you need a specific commit from meta-selinux.
+#META_SELINUX_TAG=jethro
 
 # Downloads needed for OpenXT build. Optionally replace with a local mirror.
 OPENXT_MIRROR="http://mirror.openxt.org"


### PR DESCRIPTION
commit 096a5ee ("Clone meta-selinux at known good rev.") switched
meta-selinux to using a specific commit because at the time,
meta-selinux had no jethro branch and changes in the master branch
broke the build.  Since that time, Phil created a jethro branch for
meta-selinux, so we can switch back to letting meta-selinux default
to following OE_BRANCH.   In this manner, we ensure that any subsequent
jethro-compatible fixes and improvements to meta-selinux will be picked up
by future OpenXT builds.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>