### PR TITLE
build-scripts: move the git build bits to their own script

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -39,7 +39,6 @@ BRANCH="master"
 # -- End of script configuration settings.
 
 CONTAINER_USER=%CONTAINER_USER%
-GIT_ROOT_PATH=%GIT_ROOT_PATH%
 SUBNET_PREFIX=%SUBNET_PREFIX%
 BUILD_USER="$(whoami)"
 BUILD_USER_ID="$(id -u ${BUILD_USER})"
@@ -72,25 +71,7 @@ if ! mkdir -p "${BUILD_DIR_PATH}" ; then
     exit 1
 fi
 
-# Fetch git mirrors
-for i in ${GIT_ROOT_PATH}/${BUILD_USER}/*.git; do
-    echo -n "Fetching `basename $i`: "
-    cd $i
-    git fetch --all > /dev/null 2>&1
-    git log -1 --pretty='tformat:%H'
-    cd - > /dev/null
-done | tee /tmp/git_heads_$BUILD_USER
-
-# Start the git service if needed
-ps -p `cat /tmp/openxt_git.pid 2>/dev/null` >/dev/null 2>&1 || {
-    rm -f /tmp/openxt_git.pid
-    git daemon --base-path=${GIT_ROOT_PATH} \
-               --pid-file=/tmp/openxt_git.pid \
-               --detach \
-               --syslog \
-               --export-all
-    chmod 666 /tmp/openxt_git.pid
-}
+./fetch.sh
 
 echo "Running build: ${BUILD_DIR}"
 

--- a/build-scripts/fetch.sh
+++ b/build-scripts/fetch.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+#
+# OpenXT build script.
+# Software license: see accompanying LICENSE file.
+#
+# Copyright (c) 2016 Assured Information Security, Inc.
+#
+# Contributions by Jean-Edouard Lejosne
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+GIT_ROOT_PATH=%GIT_ROOT_PATH%
+BUILD_USER="$(whoami)"
+
+# Fetch git mirrors
+for i in ${GIT_ROOT_PATH}/${BUILD_USER}/*.git; do
+    echo -n "Fetching `basename $i`: "
+    cd $i
+    git fetch --all > /dev/null 2>&1
+    git log -1 --pretty='tformat:%H'
+    cd - > /dev/null
+done | tee /tmp/git_heads_$BUILD_USER
+
+# Start the git service if needed
+ps -p `cat /tmp/openxt_git.pid 2>/dev/null` >/dev/null 2>&1 || {
+    rm -f /tmp/openxt_git.pid
+    git daemon --base-path=${GIT_ROOT_PATH} \
+               --pid-file=/tmp/openxt_git.pid \
+               --detach \
+               --syslog \
+               --export-all
+    chmod 666 /tmp/openxt_git.pid
+}

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -348,8 +348,9 @@ if [ ! -d ${GIT_ROOT_PATH}/${BUILD_USER} ]; then
 fi
 
 cp -f build.sh "${BUILD_USER_HOME}/"
+cp -f fetch.sh "${BUILD_USER_HOME}/"
 sed -i "s|\%CONTAINER_USER\%|${CONTAINER_USER}|" ${BUILD_USER_HOME}/build.sh
-sed -i "s|\%GIT_ROOT_PATH\%|${GIT_ROOT_PATH}|" ${BUILD_USER_HOME}/build.sh
 sed -i "s|\%SUBNET_PREFIX\%|${SUBNET_PREFIX}|" ${BUILD_USER_HOME}/build.sh
+sed -i "s|\%GIT_ROOT_PATH\%|${GIT_ROOT_PATH}|" ${BUILD_USER_HOME}/fetch.sh
 chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/build.sh
 echo "Done! Now login as ${BUILD_USER} and run ~/build.sh to start a build."


### PR DESCRIPTION
This allows users to fetch the git repos and/or restart the git service after a host reboot, without starting a whole new build.

OXT-507

Signed-off-by: Jed <lejosnej@ainfosec.com>