### PR TITLE
local.conf-dist: prefer LibreSSL over OpenSSL

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -74,6 +74,15 @@ INHERIT += "xenclient-src-info"
 # OpenXT specific OE tasks
 INHERIT += "xenclient-customtask"
 
+# Prefer libressl over openssl
+PREFERRED_PROVIDER_openssl = "libressl"
+PREFERRED_PROVIDER_openssl-native = "libressl-native"
+PREFERRED_PROVIDER_libcrypto = "libressl-libcrypto"
+PREFERRED_PROVIDER_libssl = "libressl-libssl"
+PREFERRED_PROVIDER_openssl-conf = "libressl-openssl-conf"
+PREFERRED_PROVIDER_nativesdk-openssl = "nativesdk-libressl"
+PREFERRED_PROVIDER_nativesdk-openssl-conf = "nativesdk-libressl-conf"
+
 # 2) Build tweaks/hacks
 
 PREFERRED_PROVIDER_console-tools = "console-tools"


### PR DESCRIPTION
This PR is to change the preferred default SSL library from OpenSSL to LibreSSL.

It has a dependency on this PR in the xenclient-oe repository:
https://github.com/OpenXT/xenclient-oe/pull/335

Refs: OXT-637

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>