### PR TITLE
Stable 6 build fix for OXT-692

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -55,7 +55,7 @@ if [ -z $1 ] ; then
     cd ${ALL_BUILDS_DIRECTORY}
     LAST_BUILD=0
     if [[ -d "${BUILD_DATE}-1" ]]; then
-	LAST_BUILD=`ls -dvr ${BUILD_DATE}-* | head -1 | cut -d '-' -f 2`
+        LAST_BUILD=`ls -dvr ${BUILD_DATE}-* | head -1 | cut -d '-' -f 2`
     fi
     cd - >/dev/null
     NEW_BUILD=$((LAST_BUILD + 1))
@@ -84,10 +84,10 @@ build_container() {
     CONTAINER_IP="${SUBNET_PREFIX}.${IP_C}.1${NUMBER}"
 
     if [ -d $NAME ]; then
-	echo "Building container $NUMBER : $NAME"
+        echo "Building container $NUMBER : $NAME"
     else
-	echo "Not building $NUMBER : $NAME"
-	return
+        echo "Not building $NUMBER : $NAME"
+        return
     fi
 
     # Build
@@ -108,10 +108,10 @@ build_windows() {
     DEST="${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/windows"
 
     if [ -d windows ]; then
-	echo "Building the Windows tools"
+        echo "Building the Windows tools"
     else
-	echo "Not building the Windows tools"
-	return
+        echo "Not building the Windows tools"
+        return
     fi
 
     mkdir -p $DEST

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -98,8 +98,8 @@ build_container() {
             -e "s|\%IP_C\%|${IP_C}|" \
             -e "s|\%BRANCH\%|${BRANCH}|" \
             -e "s|\%ALL_BUILDS_SUBDIR_NAME\%|${ALL_BUILDS_SUBDIR_NAME}|" |\
-        ssh -t -t -i "${BUILD_USER_HOME}"/ssh-key/openxt \
-            -oStrictHostKeyChecking=no ${CONTAINER_USER}@${CONTAINER_IP}
+        ssh -i "${BUILD_USER_HOME}"/ssh-key/openxt -oStrictHostKeyChecking=no \
+            ${CONTAINER_USER}@${CONTAINER_IP} '/bin/bash -s'
 }
 
 build_windows() {

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -134,15 +134,16 @@ fi
 # When installing packages, do all at once to be faster.
 PKGS="lxc"
 #PKGS="$PKGS virtualbox" # Un-comment to setup a Windows VM
-PKGS="$PKGS bridge-utils libvirt-bin curl jq git" # lxc and misc
+PKGS="$PKGS bridge-utils libvirt-bin curl jq git rsync ebtables dnsmasq" # lxc and misc
+PKGS="$PKGS haveged" # Entropy seeding
 PKGS="$PKGS debootstrap" # Debian container
 PKGS="$PKGS librpm3 librpmbuild3 librpmio3 librpmsign1 libsqlite0 python-rpm \
 python-sqlite python-sqlitecachec python-support python-urlgrabber rpm \
-rpm-common rpm2cpio yum debootstrap bridge-utils" # Centos container
+rpm-common rpm2cpio yum" # Centos container
 
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.
-apt-get install $PKGS || apt-get install $PKGS
+apt-get install -y -q $PKGS || apt-get -y -q install $PKGS
 
 # Ensure that the build user exists on the host
 if [ ! `cut -d ":" -f 1 /etc/passwd | grep "^${BUILD_USER}$"` ]; then


### PR DESCRIPTION
This PR adds the packages called out in OXT-692, cleans up some mixed whitespace, and adjusts how build.sh gets passed into the build container.