### PR TITLE
STABLE-6: build-scripts: cleanup package install

### DIFF
--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -135,10 +135,12 @@ fi
 PKGS="lxc"
 #PKGS="$PKGS virtualbox" # Un-comment to setup a Windows VM
 PKGS="$PKGS bridge-utils libvirt-bin curl jq git" # lxc and misc
+PKGS="$PKGS rsync ebtables dnsmasq"
+PKGS="$PKGS haveged" # seeds entropy
 PKGS="$PKGS debootstrap" # Debian container
 PKGS="$PKGS librpm3 librpmbuild3 librpmio3 librpmsign1 libsqlite0 python-rpm \
 python-sqlite python-sqlitecachec python-support python-urlgrabber rpm \
-rpm-common rpm2cpio yum debootstrap bridge-utils" # Centos container
+rpm-common rpm2cpio yum" # Centos container
 
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.


### PR DESCRIPTION
Add additional packages that are required for a working environment
and removed duplicate packages from list.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>
(cherry picked from commit 1c4a801fe8aa4c856a4041aa28ddfff54db0cc55)
Signed-off-by: Jed <lejosnej@ainfosec.com>

Conflicts:
	build-scripts/setup.sh