### PR TITLE
OXT-709: Add meta-intel layer to the bblayout and amend deployment scripts

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -332,6 +332,7 @@ build_iso() {
                 -boot-info-table \
                 -r \
                 -J \
+                -l \
                 -V "OpenXT-${VERSION}" \
 		-f \
 		-quiet \

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -104,6 +104,7 @@ build_image() {
             $RSYNC tmp-glibc/deploy/images/${MACHINE}/*.acm \
                    tmp-glibc/deploy/images/${MACHINE}/tboot.gz \
                    tmp-glibc/deploy/images/${MACHINE}/xen.gz \
+                   tmp-glibc/deploy/images/${MACHINE}/microcode-intel.bin \
                    ${TARGET}/netboot/
             $RSYNC tmp-glibc/deploy/images/${MACHINE}/bzImage-xenclient-dom0.bin \
                    ${TARGET}/netboot/vmlinuz

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -14,6 +14,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/repos/meta-openembedded/meta-python \
   ${TOPDIR}/repos/meta-java \
   ${TOPDIR}/repos/meta-selinux \
+  ${TOPDIR}/repos/meta-intel \
   "
 
  

--- a/do_build.sh
+++ b/do_build.sh
@@ -410,6 +410,8 @@ do_oe_installer_copy()
                 "$OUTPUT_DIR/$NAME/raw/installer/"
         cp "$binaries/$machine"/license-*.txt \
                 "$OUTPUT_DIR/$NAME/raw/installer/"
+        cp "$binaries/$machine"/microcode-intel.bin \
+                "$OUTPUT_DIR/$NAME/raw/installer"
         popd
 }
 
@@ -786,6 +788,23 @@ extract_acms()
         done
 }
 
+UCODE_LIST="microcode-intel.bin"
+extract_ucode()
+{
+        local tarball="$1"
+        local src="$2"
+        local dst="$3"
+
+        for UCODE in $UCODE_LIST; do
+            echo "    - extract $UCODE"
+            if [ -f "$src/$UCODE" ]; then
+                    cp "$src/$UCODE" "$dst/$UCODE"
+            else
+                    get_file_from_tar_or_cpio "$tarball" "boot/$UCODE" > "$dst/$UCODE"
+            fi
+        done
+}
+
 generic_do_netboot()
 {
         local suffix="$1"
@@ -821,6 +840,10 @@ generic_do_netboot()
         fi
         echo "  - extract ACMs"
         extract_acms "$tarball" "$path" "$netboot"
+
+        echo "  - extract microcode"
+        extract_ucode "$tarball" "$path" "$netboot"
+
         echo "  - copy rootfs"
         cp "$path/rootfs.i686.cpio.gz" "$netboot/rootfs.gz"
 
@@ -887,6 +910,10 @@ generic_do_installer_iso()
         fi
         echo "  - extract ACMs"
         extract_acms "$tarball" "$path/installer/" "$iso_path/isolinux"
+
+        echo "  - extract microcode"
+        extract_ucode "$tarball" "$path/installer/" "$iso_path/isolinux"
+
         echo "  - copy rootfs"
         cp "$path/installer/rootfs.i686.cpio.gz" "$iso_path/isolinux/rootfs.gz"
 

--- a/do_build.sh
+++ b/do_build.sh
@@ -410,7 +410,7 @@ do_oe_installer_copy()
                 "$OUTPUT_DIR/$NAME/raw/installer/"
         cp "$binaries/$machine"/license-*.txt \
                 "$OUTPUT_DIR/$NAME/raw/installer/"
-        cp "$binaries/$machine"/microcode-intel.bin \
+        cp "$binaries/$machine"/microcode_intel.bin \
                 "$OUTPUT_DIR/$NAME/raw/installer"
         popd
 }
@@ -788,7 +788,7 @@ extract_acms()
         done
 }
 
-UCODE_LIST="microcode-intel.bin"
+UCODE_LIST="microcode_intel.bin"
 extract_ucode()
 {
         local tarball="$1"

--- a/do_build.sh
+++ b/do_build.sh
@@ -805,13 +805,13 @@ generic_do_netboot()
         if [ -f "$path/xen.gz" ]; then
                 cp "$path/xen.gz" "$netboot/xen.gz"
         else
-                get_file_from_tar_or_cpio "$tarball" "boot/xen-3.4.1-xc.gz" > "$netboot/xen.gz"
+                get_file_from_tar_or_cpio "$tarball" "boot/xen-*-xc.gz" > "$netboot/xen.gz"
         fi
         echo "  - extract vmlinuz"
         if [ -f "$path/vmlinuz" ]; then
                 cp "$path/vmlinuz" "$netboot/vmlinuz"
         else
-                get_file_from_tar_or_cpio "$tarball" "boot/vmlinuz" > "$netboot/vmlinuz"
+                get_file_from_tar_or_cpio "$tarball" "boot/bzImage" > "$netboot/vmlinuz"
         fi
         echo "  - extract tboot.gz"
         if [ -f "$path/tboot.gz" ]; then

--- a/do_installer_iso.sh
+++ b/do_installer_iso.sh
@@ -36,6 +36,7 @@ genisoimage -o "${ISO_IMAGE}" \
         -boot-info-table \
         -r \
         -J \
+        -l \
         -V "${ISO_LABEL}" \
         -quiet \
         "${ISO_DIR}" || die "genisoimage failed"

--- a/example-config
+++ b/example-config
@@ -20,6 +20,7 @@ OE_CORE_REPO=git://git.openembedded.org/openembedded-core
 META_OE_REPO=git://git.openembedded.org/meta-openembedded
 META_JAVA_REPO=git://git.yoctoproject.org/meta-java
 META_SELINUX_REPO=git://git.yoctoproject.org/meta-selinux
+META_INTEL_REPO=git://git.yoctoproject.org/meta-intel
 
 # Use the lines below out to override checking out the branch matching the OE release
 # The commit hash for meta-java is the last commit that had openjdk6 and idedtea6

--- a/setup_build-next.sh
+++ b/setup_build-next.sh
@@ -71,7 +71,7 @@ mkdir -p $REPOS || die "Could not create local build dir"
 # Pull down the OpenXT repos
 process_git_repo $REPOS/xenclient-oe $XENCLIENT_REPO $XENCLIENT_TAG
 process_git_repo $REPOS/bitbake $BITBAKE_REPO $BB_BRANCH
-for repo in openembedded-core meta-openembedded meta-java meta-selinux; do
+for repo in openembedded-core meta-openembedded meta-java meta-selinux meta-intel; do
     repo_var=`echo $repo | sed -e 's/openembedded/oe/' -e 's/-/_/' | tr '[a-z]' '[A-Z]'`
     git_var="${repo_var}_REPO"
     git=${!git_var}


### PR DESCRIPTION
Add meta-intel to the layers used in OpenXT in order to provide upstream tools to manage Intel microcode.

Amend the deployment scripts (do_build.sh and do_installer_iso.sh) to ship the microcode update with the installer so Xen can perform the update when booting on OpenXT installer.

Last commit add a change to genisoimage and what standard is enforced for file names in OpenXT ISO images to avoid mangling names more than 8 characters + '.' + up to 3 characters long.

OXT-709