### PR TITLE
OXT-743: Fix microcode changes for build-scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,7 @@
 	path = build/repos/meta-selinux
 	url = git://git.yoctoproject.org/meta-selinux
 	branch = jethro
+[submodule "build/repos/meta-intel"]
+	path = build/repos/meta-intel
+	url = git://git.yoctoproject.org/meta-intel
+	branch = jethro

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -104,7 +104,7 @@ build_image() {
             $RSYNC tmp-glibc/deploy/images/${MACHINE}/*.acm \
                    tmp-glibc/deploy/images/${MACHINE}/tboot.gz \
                    tmp-glibc/deploy/images/${MACHINE}/xen.gz \
-                   tmp-glibc/deploy/images/${MACHINE}/microcode-intel.bin \
+                   tmp-glibc/deploy/images/${MACHINE}/microcode_intel.bin \
                    ${TARGET}/netboot/
             $RSYNC tmp-glibc/deploy/images/${MACHINE}/bzImage-xenclient-dom0.bin \
                    ${TARGET}/netboot/vmlinuz


### PR DESCRIPTION
Typo due to renaming for ISO9660 consistency.
Add meta-intel to the git submodules.