### PR TITLE
[build scripts] add -j command option to specify build concurrency

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -45,13 +45,16 @@ NO_DEBIAN=
 NO_CENTOS=
 NO_WINDOWS=
 
+THREADS=
+
 # -- End of script configuration settings.
 
 usage() {
     cat >&2 <<EOF
-usage: $0 [-h] [-i ID] [-b branch] [-n build] [-O] [-D] [-C] [-W]
+usage: $0 [-h] [-i ID] [-j threads] [-b branch] [-n build] [-O] [-D] [-C] [-W]
   -h: Help
   -i: Build ID (overrides -n)
+  -j: Number of concurrent threads
   -b: Branch to build
   -n: Continue the specified build instead of creating a new one
   -O: Do not build OpenEmbedded (OpenXT core), not recommended
@@ -65,13 +68,16 @@ EOF
     exit $1
 }
 
-while getopts "hi:b:n:ODCW" opt; do
+while getopts "hi:j:b:n:ODCW" opt; do
     case $opt in
         h)
             usage 0
             ;;
         i)
             BUILD_ID=${OPTARG}
+            ;;
+        j)
+            THREADS=${OPTARG}
             ;;
         b)
             BRANCH="${OPTARG}"
@@ -174,6 +180,7 @@ build_container() {
             -e "s|\%IP_C\%|${IP_C}|" \
             -e "s|\%BUILD_ID\%|${BUILD_ID}|" \
             -e "s|\%BRANCH\%|${BRANCH}|" \
+            -e "s|\%THREADS\%|${THREADS}|" \
             -e "s|\%ALL_BUILDS_SUBDIR_NAME\%|${ALL_BUILDS_SUBDIR_NAME}|" |\
         ssh -t -t -i "${BUILD_USER_HOME}"/ssh-key/openxt \
             -oStrictHostKeyChecking=no ${CONTAINER_USER}@${CONTAINER_IP}

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -27,6 +27,7 @@ BUILD_DIR=%BUILD_DIR%
 IP_C=%IP_C%
 BUILD_ID=%BUILD_ID%
 BRANCH=%BRANCH%
+THREADS=%THREADS%
 SUBNET_PREFIX=%SUBNET_PREFIX%
 ALL_BUILDS_SUBDIR_NAME=%ALL_BUILDS_SUBDIR_NAME%
 
@@ -73,6 +74,13 @@ XCT_DEB_PKGS_DIR := "${BUILD_PATH}/xct_deb_packages"
 REPO_PROD_CACERT="/home/${LOCAL_USER}/certs/prod-cacert.pem"
 REPO_DEV_CACERT="/home/${LOCAL_USER}/certs/dev-cacert.pem"
 EOF
+}
+
+configure_threads() {
+    if [ ! -z ${THREADS} ] ; then
+        sed -i 's/^BB_NUMBER_THREADS .*$/BB_NUMBER_THREADS ?= "'"${THREADS}"'"/' build/conf/local.conf
+        sed -i 's/^PARALLEL_MAKE .*$/PARALLEL_MAKE ?= "'"-j ${THREADS}"'"/' build/conf/local.conf
+    fi
 }
 
 build_image() {
@@ -186,6 +194,8 @@ if [ ! -d openxt ] ; then
 else
     cd openxt
 fi
+
+configure_threads
 
 # Build
 mkdir -p build


### PR DESCRIPTION
Argument is only used in the OE build in this initial version.

Configures BB_NUMBER_THREADS and PARALLEL_MAKE variables.
Supports adjusting the value when continuing an existing build.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>