### PR TITLE
[build-scripts] Improve BUILD_ID and BUILD_DIR generation

### DIFF
--- a/build-scripts/clean.sh
+++ b/build-scripts/clean.sh
@@ -49,7 +49,7 @@ if [ "$IN_CONTAINER" = "y" ]; then
         exit 0
     fi
 
-    BDLIST=`ls | grep -e "^[0-9]\{6\}-[0-9]\+$"`
+    BDLIST=`ls | grep -e "^[0-9]\{6\}\(-[0-9]\+\)\?$"`
     for i in $BDLIST; do
         echo "Cleaning up: $i"
         rm -rf $i
@@ -138,7 +138,7 @@ if [ -n "$BUILD_DIR" ]; then
     exit 0
 fi
 
-BDLIST=`ls xt-builds | grep -e "^[0-9]\{6\}-[0-9]\+$"`
+BDLIST=`ls xt-builds | grep -e "^[0-9]\{6\}\(-[0-9]\+\)\?$"`
 for i in $BDLIST; do
     echo "Cleaning up: xt-builds/$i"
     rm -rf xt-builds/$i

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -288,6 +288,7 @@ sed -i "s|\%SUBNET_PREFIX\%|${SUBNET_PREFIX}|" ${BUILD_USER_HOME}/build.sh
 sed -i "s|\%CONTAINER_USER\%|${CONTAINER_USER}|" ${BUILD_USER_HOME}/clean.sh
 sed -i "s|\%SUBNET_PREFIX\%|${SUBNET_PREFIX}|" ${BUILD_USER_HOME}/clean.sh
 sed -i "s|\%GIT_ROOT_PATH\%|${GIT_ROOT_PATH}|" ${BUILD_USER_HOME}/fetch.sh
+sed -i "s|\%GIT_ROOT_PATH\%|${GIT_ROOT_PATH}|" ${BUILD_USER_HOME}/build.sh
 chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/build.sh
 chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/clean.sh
 chown ${BUILD_USER}:${BUILD_USER} ${BUILD_USER_HOME}/fetch.sh


### PR DESCRIPTION
By default, build ID was not including the unique build directory
suffix, so all builds on the same date would have the same build ID.

Take this opportunity to tidy up the Build ID and Build directory
assignment logic.

Signed-off-by: Christopher Clark christopher.clark6@baesystems.com
