### PR TITLE
STABLE-5: Change kernel.org mirror.

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -112,6 +112,8 @@ do_populate_sysroot_setscene[dirs] = "${WORKDIR}"
 do_make_scripts[dirs] = "${WORKDIR}"
 #do_repo_clean[dirs] = "${WORKDIR}"
 
+# overwrite kernel.org mirror to use cdn.kernel.org
+KERNELORG_MIRROR = "https://cdn.kernel.org/pub"
 
 # overwrite debian mirror for screen, as the debian version it's based on (lenny) is in oldstable now
 DEBIAN_MIRROR_pn-screen = "http://archive.debian.org/debian/pool"


### PR DESCRIPTION
Fetch from cdn.kernel.org

wget < 1.12 or 1.13 has trouble fetching from www.kernel.org since it
allows only use of TLS (so squeeze/wheezy containers might have issue
downloading kernel tarballs).

Nevertheless, it seems we should fetch from cdn.kernel.org anyway.

https://www.kernel.org/introducing-fastly-cdn.html
