### PR TITLE
STABLE-6: local.conf-dist: hardcode 8 threads instead of 4

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -1,8 +1,8 @@
 # 1) Basic config
 DISTRO = "openxt-main"
 DISTRO_FEATURES = "alsa ext2 largefile usbhost wifi xattr pci x11 ipv4 ipv6 ${DISTRO_FEATURES_LIBC} multiarch pam"
-BB_NUMBER_THREADS ?= "4"
-PARALLEL_MAKE ?= "-j 4"
+BB_NUMBER_THREADS ?= "8"
+PARALLEL_MAKE ?= "-j 8"
 PACKAGE_CLASSES ?= "package_ipk"
 EXTRA_IMAGE_FEATURES = "debug-tweaks"
 #USER_CLASSES ?= "buildstats image-mklibs image-prelink"


### PR DESCRIPTION
Using the new build scripts, there's no way to specify how many threads we want to build OpenXT.
The default, 4, seems really weak, 8 should make more sense on most build machines.
This PR is very low priority, do not bother cutting a new 6.0.1 RC just for that.

Signed-off-by: Jed <lejosnej@ainfosec.com>