### PR TITLE
STABLE-6: do_build.sh: make XENCLIENT_PACKAGE_FEED_URI configurable

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -107,10 +107,13 @@ EOF
 PREMIRRORS = "(ftp|https?)$://.*/.*/ ${OE_TARBALL_MIRROR}"
 EOF
                 fi
+                if [ -z "${XENCLIENT_PACKAGE_FEED_URI}" ]; then
+                    XENCLIENT_PACKAGE_FEED_URI="${NETBOOT_HTTP_URL}/${BRANCH}/${NAME}/packages/ipk"
+                fi
                 cat >> conf/local.conf <<EOF
 
 # Distribution feed
-XENCLIENT_PACKAGE_FEED_URI="${NETBOOT_HTTP_URL}/${BRANCH}/${NAME}/packages/ipk"
+XENCLIENT_PACKAGE_FEED_URI = "$XENCLIENT_PACKAGE_FEED_URI"
 
 # Local generated configuration for build $ID
 INHERIT += "$EXTRA_CLASSES"


### PR DESCRIPTION
This is needed for the new build server to configure opkg correctly, since it doesn't match the hardcoded URI layout.

Signed-off-by: Jed <lejosnej@ainfosec.com>