### PR TITLE
[upgrade] Since 6.0.0 does not support wildcards, add it explicitly.

### DIFF
--- a/version
+++ b/version
@@ -17,4 +17,4 @@ XC_TOOLS_MINOR="0"
 XC_TOOLS_MICRO="0"
 
 # Space-separated list of previous releases that can be upgraded from
-UPGRADEABLE_RELEASES="6.0.*"
+UPGRADEABLE_RELEASES="6.0.0 6.0.*"


### PR DESCRIPTION
OXT-910

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>