### PR TITLE
build-scripts: debian: setup.sh: add missing package in chroots

### DIFF
--- a/build-scripts/debian/setup.sh
+++ b/build-scripts/debian/setup.sh
@@ -29,7 +29,8 @@ passwd -d root
 # Install required packages
 PKGS=""
 PKGS="$PKGS openssh-server openssl git"
-PKGS="$PKGS schroot sbuild reprepro dh-make dkms pkg-config" # Debian package building deps
+# Debian package building deps
+PKGS="$PKGS schroot sbuild reprepro dh-make dkms pkg-config libfile-fcntllock-perl"
 apt-get update
 apt-get -y install $PKGS </dev/null
 


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>