### PR TITLE
STABLE-6: Have to add KBL to do_build.sh too in 6.x.

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -767,7 +767,7 @@ do_updates()
         done
 }
 
-ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm bdw.acm skl.acm"
+ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm bdw.acm skl.acm kbl.acm"
 ACM_LICENSE="license-SINIT-ACMs.txt"
 
 extract_acms()


### PR DESCRIPTION
OXT-887

Signed-off-by: Ross Philipson <philipsonr@ainfosec.com>