### PR TITLE
do_build.sh: Add meta-virtualization layer handling.

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -104,7 +104,7 @@ EOF
             mkdir -p conf
         fi
 
-        if [ ! -f "conf/local.conf" ]; then
+        if [ ! -f "conf/local.conf" -o "conf/local.conf" -ot "conf/local.conf-dist" ]; then
                 cp conf/local.conf-dist conf/local.conf
 
                 if [ ! -z "${OE_TARBALL_MIRROR}" ] ; then

--- a/do_build.sh
+++ b/do_build.sh
@@ -53,7 +53,7 @@ do_oe_setup()
 
         echo "*:$BRANCH" > "manifest"
 
-        for layer in meta-openxt-ocaml-platform meta-openxt-haskell-platform xenclient-oe; do
+        for layer in meta-openxt-ocaml-platform meta-openxt-haskell-platform meta-virtualization xenclient-oe; do
             if ! grep $layer conf/bblayers.conf >/dev/null; then
                 echo "BBLAYERS =+ \"\${TOPDIR}/repos/${layer}\"" >> conf/bblayers.conf
             fi

--- a/example-config
+++ b/example-config
@@ -23,6 +23,7 @@ META_SELINUX_REPO=git://git.yoctoproject.org/meta-selinux
 META_INTEL_REPO=git://git.yoctoproject.org/meta-intel
 META_OPENXT_OCAML_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-ocaml-platform.git
 META_OPENXT_HASKELL_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-haskell-platform.git
+META_VIRTUALIZATION_REPO=git://git.yoctoproject.org/meta-virtualization.git
 
 # Use the lines below out to override checking out the branch matching the OE release
 # The commit hash for meta-java is the last commit that had openjdk6 and idedtea6

--- a/setup_build
+++ b/setup_build
@@ -68,6 +68,9 @@ META_OPENXT_OCAML_PLATFORM_TAG=master
 
 META_OPENXT_HASKELL_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-haskell--platform.git
 META_OPENXT_HASKELL_PLATFORM_TAG=master
+
+META_VIRTUALIZATION_REPO=git://git.yoctoproject.org/meta-virtualization.git
+META_VIRTUALIZATION_TAG=jethro
 # End of configuration
 
 die() {
@@ -120,6 +123,7 @@ if [ "$1" != "env" ]; then
   getgit $REPOS/meta-selinux $META_SELINUX_REPO $META_SELINUX_TAG
   getgit $REPOS/meta-openxt-ocaml-platform $META_OPENXT_OCAML_PLATFORM_REPO $META_OPENXT_OCAML_PLATFORM_TAG
   getgit $REPOS/meta-openxt-haskell-platform $META_OPENXT_HASKELL_PLATFORM_REPO $META_OPENXT_HASKELL_PLATFORM_TAG
+  getgit $REPOS/meta-virtualization $META_VIRTUALIZATION_REPO $META_VIRTUALIZATION_TAG
 fi
 
 if [ ! -e $OE_XENCLIENT_DIR/conf/local.conf ]; then

--- a/setup_build
+++ b/setup_build
@@ -66,7 +66,7 @@ META_SELINUX_TAG=8e952c7da126d30f4aecb33abd3ef9252785cb40
 META_OPENXT_OCAML_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-ocaml-platform.git
 META_OPENXT_OCAML_PLATFORM_TAG=master
 
-META_OPENXT_HASKELL_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-haskell--platform.git
+META_OPENXT_HASKELL_PLATFORM_REPO=https://github.com/OpenXT/meta-openxt-haskell-platform.git
 META_OPENXT_HASKELL_PLATFORM_TAG=master
 
 META_VIRTUALIZATION_REPO=git://git.yoctoproject.org/meta-virtualization.git

--- a/setup_build-next.sh
+++ b/setup_build-next.sh
@@ -71,7 +71,7 @@ mkdir -p $REPOS || die "Could not create local build dir"
 # Pull down the OpenXT repos
 process_git_repo $REPOS/xenclient-oe $XENCLIENT_REPO $XENCLIENT_TAG
 process_git_repo $REPOS/bitbake $BITBAKE_REPO $BB_BRANCH
-for repo in openembedded-core meta-openembedded meta-java meta-selinux meta-intel meta-openxt-ocaml-platform meta-openxt-haskell-platform; do
+for repo in openembedded-core meta-openembedded meta-java meta-selinux meta-intel meta-openxt-ocaml-platform meta-openxt-haskell-platform meta-virtualization; do
     repo_var=`echo $repo | sed -e 's/openembedded/oe/' -e 's/-/_/g' | tr '[a-z]' '[A-Z]'`
     git_var="${repo_var}_REPO"
     git=${!git_var}


### PR DESCRIPTION
do_build is deprecated, it is recommended to use the build-scripts. Yet some people might still have setups using the legacy script.