### PR TITLE
OXT-1016 : capture core2-32 packages for each machine build

### DIFF
--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -135,11 +135,28 @@ build_image() {
     fi
 }
 
-collect_packages() {
-    # Build the extra packages
+build_extra_packages() {
     MACHINE=xenclient-dom0 ./bb packagegroup-xenclient-extra | tee -a build.log
     MACHINE=xenclient-dom0 ./bb package-index | tee -a build.log
+}
 
+stash_core2_packages() {
+    collection=$1
+    $RSYNC -rt tmp-glibc/deploy/ipk/core2-32/ \
+               tmp-glibc/deploy/ipk/core2-32.$collection/
+}
+
+dedupe_core2_packages() {
+    for pkgdir in tmp-glibc/deploy/ipk/core2-32.* ; do
+        for pkg in ${pkgdir}/* ; do
+            if diff -q $pkg tmp-glibc/deploy/ipk/core2-32/ ; then
+                rm $pkg
+            fi
+        done
+    done
+}
+
+collect_packages() {
     $RSYNC tmp-glibc/deploy/ipk ${TARGET}/packages
 }
 
@@ -215,9 +232,12 @@ for layer in $openxt_layers; do
         format=`echo $image | awk '{print $3}'`
         echo "Building $step for $machine in $format"
         build_image $machine $step $format
+        stash_core2_packages $machine
     done
 done
 
+build_extra_packages
+dedupe_core2_packages
 collect_packages
 collect_logs
 

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -142,16 +142,16 @@ build_extra_packages() {
 
 stash_core2_packages() {
     collection=$1
-    $RSYNC -rt tmp-glibc/deploy/ipk/core2-32/ \
+    $RSYNC -rt --link-dest=`pwd`/tmp-glibc/deploy/ipk/core2-32 \
+               tmp-glibc/deploy/ipk/core2-32/ \
                tmp-glibc/deploy/ipk/core2-32.$collection/
 }
 
 dedupe_core2_packages() {
     for pkgdir in tmp-glibc/deploy/ipk/core2-32.* ; do
+        [ "$(ls ${pkgdir} | wc -l)" != "0" ] || continue
         for pkg in ${pkgdir}/* ; do
-            if diff -q $pkg tmp-glibc/deploy/ipk/core2-32/ ; then
-                rm $pkg
-            fi
+            [ "$(stat -c '%h' $pkg)" == "1" ] || rm $pkg
         done
     done
 }


### PR DESCRIPTION
Some of the core2-32 packages are rebuilt for different MACHINEs
so ensure that the package archive captures all variants.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>