### PR TITLE
OXT-1016: Only build the Xen recipes once per build

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -21,10 +21,10 @@ LOCALE_UTF8_ONLY = "1"
 
 # ocaml
 SYSROOT_OCAML_PATH = "${STAGING_DIR_NATIVE}${libdir_native}/${TRANSLATED_TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS}/ocaml"
-OCAML_STDLIBDIR = "${SYSROOT_OCAML_PATH}/site-lib"
+export OCAML_STDLIBDIR = "${SYSROOT_OCAML_PATH}/site-lib"
 OCAML_HEADERS = "${SYSROOT_OCAML_PATH}"
 export ocamllibdir = "${libdir}/ocaml"
-STAGING_LIBDIR_OCAML = "${STAGING_LIBDIR}/ocaml"
+export STAGING_LIBDIR_OCAML = "${STAGING_LIBDIR}/ocaml"
 OCAML_FINDLIB_CONF = "${STAGING_DIR_HOST}${sysconfdir}/findlib.conf"
 
 # vhd image format support 


### PR DESCRIPTION
PRs for: xenclient-oe, openxt and meta-openxt-ocaml-platform.

Export OCaml variables for the ocaml findlib wrapper.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>