### PR TITLE
OXT-1187: xen: upgrade to 4.6.6

### DIFF
--- a/common-config
+++ b/common-config
@@ -1,5 +1,5 @@
 # xen version and source archive
-XEN_VERSION="4.6.5"
-XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.6.5/xen-4.6.5.tar.gz"
-XEN_SRC_MD5SUM="63c80317ee662fb237d709d6c4e161c8"
-XEN_SRC_SHA256SUM="08b68d00eb6a71ec16aba1168def5ab070781868b1a81b54f2a6e61587efed56"
+XEN_VERSION="4.6.6"
+XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.6.6/xen-4.6.6.tar.gz"
+XEN_SRC_MD5SUM="698328dcac775c8ccef0da3167020b19"
+XEN_SRC_SHA256SUM="fa0748f128b189ec3497470a95f53ea42bbe4d7b5622509bcd862877895842f8"


### PR DESCRIPTION
See release notes:
https://www.xenproject.org/downloads/xen-archives/xen-46-series/xen-466.html

Depends on: https://github.com/OpenXT/xenclient-oe/pull/724