### PR TITLE
STABLE-6: Only allow upgrades from 6.0.0

### DIFF
--- a/version
+++ b/version
@@ -17,4 +17,4 @@ XC_TOOLS_MINOR="0"
 XC_TOOLS_MICRO="0"
 
 # Space-separated list of previous releases that can be upgraded from
-UPGRADEABLE_RELEASES="5.0.1 6.0.0"
+UPGRADEABLE_RELEASES="6.0.0"


### PR DESCRIPTION
OXT-1188

Signed-off-by: Jed <lejosnej@ainfosec.com>