### PR TITLE
[Xen 4.9] Update Xen hypervisor and tools to latest major release 4.9.0

### DIFF
--- a/common-config
+++ b/common-config
@@ -1,5 +1,5 @@
 # xen version and source archive
-XEN_VERSION="4.6.6"
-XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.6.6/xen-4.6.6.tar.gz"
-XEN_SRC_MD5SUM="698328dcac775c8ccef0da3167020b19"
-XEN_SRC_SHA256SUM="fa0748f128b189ec3497470a95f53ea42bbe4d7b5622509bcd862877895842f8"
+XEN_VERSION="4.9.0"
+XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.9.0/xen-4.9.0.tar.gz"
+XEN_SRC_MD5SUM="f0a753637630f982dfbdb64121fd71e1"
+XEN_SRC_SHA256SUM="cade643fe3310d4d6f97d0c215c6fa323bc1130d7e64d7e2043ffaa73a96f33b"


### PR DESCRIPTION
OXT-1203 for Xen upgrade.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>