### PR TITLE
build-scripts: limit build user to less than 13 characters

### DIFF
--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -119,6 +119,10 @@ while getopts "hODCWu:d:c:s:m:r:g:w:" opt; do
             ;;
         u)
             BUILD_USER="${OPTARG}"
+            if [ ${#BUILD_USER} -ge 13 ]; then
+                echo Error: build user too long, please pick a name shorter than 13 characters >&2
+                exit 5
+            fi
             ;;
         d)
             DEBIAN_MIRROR="${OPTARG}"


### PR DESCRIPTION
We create a bridge named \<user\>br0, and bridge names have to be shorter than 16 characters.

Signed-off-by: Jed <lejosnej@ainfosec.com>