### PR TITLE
OXT-1256: xen: 4.9.1 Uprev

### DIFF
--- a/common-config
+++ b/common-config
@@ -1,5 +1,5 @@
 # xen version and source archive
-XEN_VERSION="4.9.0"
-XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.9.0/xen-4.9.0.tar.gz"
-XEN_SRC_MD5SUM="f0a753637630f982dfbdb64121fd71e1"
-XEN_SRC_SHA256SUM="cade643fe3310d4d6f97d0c215c6fa323bc1130d7e64d7e2043ffaa73a96f33b"
+XEN_VERSION="4.9.1"
+XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.9.1/xen-4.9.1.tar.gz"
+XEN_SRC_MD5SUM="8b9d6104694b164d54334194135f7217"
+XEN_SRC_SHA256SUM="ecf88b01f44cd8f4ef208af3f999dceb69bdd2a316d88dd9a9535ea7b49ed356"


### PR DESCRIPTION
Update to the latest Xen 4.9.1 release.

OXT-1256

Requires https://github.com/OpenXT/xenclient-oe/pull/810

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>