### PR TITLE
OXT-1280: UEFI support

### DIFF
--- a/build-scripts/20-xenclient-oe.layer
+++ b/build-scripts/20-xenclient-oe.layer
@@ -11,8 +11,8 @@ openxt_layer_xenclient_oe_images=(                                          \
 "xenclient-stubdomain   xenclient-stubdomain-initramfs      cpio.gz"        \
 "xenclient-dom0         xenclient-initramfs                 cpio.gz"        \
 "xenclient-dom0         xenclient-dom0                      xc.ext3.gz"     \
-"xenclient-dom0         xenclient-installer                 cpio.gz"        \
-"xenclient-dom0         xenclient-installer-part2           tar.bz2"        \
+"openxt-installer       xenclient-installer                 cpio.gz"        \
+"openxt-installer       xenclient-installer-part2           tar.bz2"        \
 "xenclient-uivm         xenclient-uivm                      xc.ext3.vhd.gz" \
 "xenclient-ndvm         xenclient-ndvm                      xc.ext3.vhd.gz" \
 )

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -117,7 +117,7 @@ build_image() {
                 $RSYNC tmp-glibc/deploy/images/${MACHINE}/microcode_intel.bin \
                        ${TARGET}/netboot/
             fi
-            $RSYNC tmp-glibc/deploy/images/${MACHINE}/bzImage-xenclient-dom0.bin \
+            $RSYNC tmp-glibc/deploy/images/${MACHINE}/bzImage-${MACHINE}.bin \
                    ${TARGET}/netboot/vmlinuz
         else
             $RSYNC ${SOURCE_IMAGE} ${TARGET}/raw/${REAL_NAME}-rootfs.i686.${EXTENSION}
@@ -132,6 +132,12 @@ build_image() {
     # Transfer additionnal files
     if [ -d ${SOURCE_EXTRAS} ]; then
         $RSYNC ${SOURCE_EXTRAS}/ ${TARGET}/${REAL_NAME}
+    fi
+
+    # Transfer installer EFI files
+    if [ -f tmp-glibc/deploy/images/${MACHINE}/grubx64.efi ]; then
+        $RSYNC tmp-glibc/deploy/images/${MACHINE}/grubx64.efi ${TARGET}/raw/
+        $RSYNC tmp-glibc/deploy/images/${MACHINE}/isohdpfx.bin ${TARGET}/raw/
     fi
 }
 

--- a/build-scripts/oe/setup.sh
+++ b/build-scripts/oe/setup.sh
@@ -32,7 +32,8 @@ sed -i '/^start)$/a        mkdir -p /dev/shm/network/' /etc/init.d/networking
 PKGS=""
 PKGS="$PKGS openssh-server openssl"
 PKGS="$PKGS sed wget cvs subversion git-core coreutils unzip texi2html texinfo docbook-utils gawk python-pysqlite2 diffstat help2man make gcc build-essential g++ desktop-file-utils chrpath cpio screen bash-completion" # OE main deps
-PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev" # OpenXT-specific deps
+PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev libc6-dev-amd64" # OpenXT-specific deps
+PKGS="$PKGS xorriso fusefat dosfstools" # installer & efiboot.img
 
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -163,13 +163,14 @@ fi
 
 # Ensure that all required packages are installed on this host.
 # When installing packages, do all at once to be faster.
-DEB_PKGS="lxc bridge-utils libvirt-daemon-system libvirt-clients curl jq genisoimage git"
+DEB_PKGS="lxc bridge-utils libvirt-daemon-system libvirt-clients curl jq genisoimage xorriso git"
 DEB_PKGS="$DEB_PKGS syslinux-utils openssl unzip rsync ebtables dnsmasq"
 DEB_PKGS="$DEB_PKGS haveged" # seeds entropy
 DEB_PKGS="$DEB_PKGS debootstrap" # Debian container
 DEB_PKGS="$DEB_PKGS librpm3 librpmbuild3 librpmio3 libsqlite0 python-rpm \
 python-sqlite python-sqlitecachec python-urlgrabber rpm \
 rpm-common rpm2cpio yum" # Centos container
+DEB_PKGS="$DEB_PKGS dosfstools fuse fusefat" # efiboot.img
 
 # Version-specific Debian packages
 DEB_VERS=`cut -d '.' -f 1 /etc/debian_version`


### PR DESCRIPTION
This PR includes the changes necessary for building OpenXT with UEFI support. The two major changes are the splitting of the `openxt-installer` into its own machine type and using `xorriso` to build an ISO image bootable both under legacy and UEFI.

Related PRs:
https://github.com/OpenXT/xenclient-oe/pull/828
https://github.com/OpenXT/installer/pull/63