### PR TITLE
STABLE-8: do_build.sh: Use mtools instead of fuse for UEFI

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -350,13 +350,10 @@ build_iso() {
     EFIBOOTIMG="iso_tmp/isolinux/efiboot.img"
     dd if=/dev/zero bs=1M count=5 of=${EFIBOOTIMG}
     /sbin/mkfs.fat ${EFIBOOTIMG}
-    mkdir -p efi_tmp
-    fusefat -o rw+ ${EFIBOOTIMG} efi_tmp
-    mkdir -p efi_tmp/EFI/BOOT
-    cp -f raw/grubx64.efi efi_tmp/EFI/BOOT/BOOTX64.EFI
+    mmd -i ${EFIBOOTIMG} EFI
+    mmd -i ${EFIBOOTIMG} EFI/BOOT
+    mcopy -i ${EFIBOOTIMG} raw/grubx64.efi ::EFI/BOOT/BOOTX64.EFI
     sync
-    fusermount -u efi_tmp
-    rm -rf efi_tmp
 
     echo "Creating installer.iso..."
     xorriso -as mkisofs \

--- a/build-scripts/oe/setup.sh
+++ b/build-scripts/oe/setup.sh
@@ -33,7 +33,7 @@ PKGS=""
 PKGS="$PKGS openssh-server openssl"
 PKGS="$PKGS sed wget cvs subversion git-core coreutils unzip texi2html texinfo docbook-utils gawk python-pysqlite2 diffstat help2man make gcc build-essential g++ desktop-file-utils chrpath cpio screen bash-completion python3 iputils-ping" # OE main deps
 PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev libc6-dev-amd64 libelf-dev" # OpenXT-specific deps
-PKGS="$PKGS xorriso fusefat dosfstools" # installer & efiboot.img
+PKGS="$PKGS xorriso mtools dosfstools" # installer & efiboot.img
 
 apt-get update
 # That's a lot of packages, a fetching failure can happen, try twice.

--- a/do_build.sh
+++ b/do_build.sh
@@ -916,13 +916,10 @@ generic_do_installer_iso()
         echo "  - create efiboot.img"
         dd if=/dev/zero bs=1M count=5 of=${EFIBOOTIMG}
         /sbin/mkfs.fat ${EFIBOOTIMG}
-        mkdir -p efi_tmp
-        fusefat -o rw+ ${EFIBOOTIMG} efi_tmp
-        mkdir -p efi_tmp/EFI/BOOT
-        cp -f "$path/grubx64.efi" efi_tmp/EFI/BOOT/BOOTX64.EFI
+        mmd -i ${EFIBOOTIMG} EFI
+        mmd -i ${EFIBOOTIMG} EFI/BOOT
+        mcopy -i ${EFIBOOTIMG} "$path/grubx64.efi" ::EFI/BOOT/BOOTX64.EFI
         sync
-        fusermount -u efi_tmp
-        rm -rf efi_tmp
 
         echo "  - create iso"
         "${CMD_DIR}/do_installer_iso.sh" "$iso_path" "$iso_path.iso" "$OPENXT_ISO_LABEL" "$path/isohdpfx.bin"


### PR DESCRIPTION
fuse doesn't play nicely in a container environment since it wants to
load modules and do other privileged operations.  Instead use mtools
which can just be run as the user.

OXT-1280

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 9642a3244d90068f6c311c539054a87af009c28f)