### PR TITLE
STABLE-8: build.sh: do not assume there is a Windows VM

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -200,7 +200,12 @@ build_windows() {
 
     DEST="${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/windows"
 
-    echo "Building the Windows tools"
+    if [ -d windows ]; then
+        echo "Building the Windows tools"
+    else
+        echo "Skipping the Windows tools"
+        return
+    fi
 
     mkdir -p $DEST
 


### PR DESCRIPTION
setup.sh does not setup a Windows VM by default,
so build.sh should not assume there is one.

OXT-507

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit 8ead1492f45b047fe6dfcabac3b0a205a19cbaa9)
Signed-off-by: Jed <lejosnej@ainfosec.com>