### PR TITLE
STABLE-8: build-scripts: openxt prefix was dropped from the v4v deb package name

### DIFF
--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -7,7 +7,7 @@ set -e
 cd `dirname $0`
 
 VERSION=%VERSION%
-DKMS_PACKAGES="openxt-v4v-dkms openxt-vusb-dkms openxt-xenmou-dkms"
+DKMS_PACKAGES="v4v-dkms openxt-vusb-dkms openxt-xenmou-dkms"
 OTHER_PACKAGES="libv4v"
 
 DEBIAN_NAME=jessie


### PR DESCRIPTION
Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>