### PR TITLE
STABLE-8: OXT-1310: do_build.sh: Add Coffee Lake ACM

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -761,7 +761,7 @@ do_updates()
         done
 }
 
-ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm bdw.acm skl.acm kbl.acm"
+ACM_LIST="ivb_snb.acm gm45.acm duali.acm quadi.acm q35.acm q45q43.acm xeon56.acm xeone7.acm hsw.acm bdw.acm skl.acm kbl.acm cfl.acm"
 ACM_LICENSE="license-SINIT-ACMs.txt"
 
 extract_acms()


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/openxt/pull/312

The Coffee Lake ACM is needed otherwise isolinux fails to boot because
it cannot find the cfl.acm file.

OXT-1310

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 1d18021ac1a16298dfb76e726383302b1264693d)