### PR TITLE
Openxt client tool install signing for 18.04+

### DIFF
--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -35,7 +35,7 @@ cp -r debian /var/opt/openxt/
 
 echo "Writing /etc/apt/sources.list.d/openxt.list"
 cat > /etc/apt/sources.list.d/openxt.list <<EOF
-deb file:///var/opt/openxt/debian $DEBIAN_NAME main
+deb [trusted=yes] file:///var/opt/openxt/debian $DEBIAN_NAME main
 EOF
 
 echo "Installing the tools..."


### PR DESCRIPTION
Add source as trusted before install to allow install without disabling apt source signing.

Tested on Ubuntu 18.04