### PR TITLE
do_build: Fix bash syntax

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -32,7 +32,7 @@ export BUILD_UID
 
 # TODO: move some of the above definitions into common-config
 
-if [ -f ${CMD_DIR}/common-config ]
+if [ -f ${CMD_DIR}/common-config ]; then
     source ${CMD_DIR}/common-config
 fi
 source ${CMD_DIR}/build_helpers.sh


### PR DESCRIPTION
This fixes the syntax error aborting the script:
"./do_build.sh: line 37: syntax error near unexpected token `fi'"

OXT-1346

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>