### PR TITLE
OXT-1346: xen: Move version management to the recipes.

### DIFF
--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -43,7 +43,9 @@ cd ..
 setupoe() {
     source version
     cp build/conf/local.conf-dist build/conf/local.conf
-    cat common-config >> build/conf/local.conf
+    if [ -f common-config ]; then
+        cat common-config >> build/conf/local.conf
+    fi
     cat >> build/conf/local.conf <<EOF
 # Distribution feed
 XENCLIENT_PACKAGE_FEED_URI="file:///storage/ipk"

--- a/common-config
+++ b/common-config
@@ -1,5 +1,0 @@
-# xen version and source archive
-XEN_VERSION="4.10.0"
-XEN_SRC_URI="https://downloads.xenproject.org/release/xen/4.10.0/xen-4.10.0.tar.gz"
-XEN_SRC_MD5SUM="ab9d320d02cb40f6b40506aed1a38d58"
-XEN_SRC_SHA256SUM="0262a7023f8b12bcacfb0b25e69b2a63291f944f7683d54d8f33d4b2ca556844"

--- a/do_build.sh
+++ b/do_build.sh
@@ -32,7 +32,9 @@ export BUILD_UID
 
 # TODO: move some of the above definitions into common-config
 
-source ${CMD_DIR}/common-config
+if [ -f ${CMD_DIR}/common-config ]
+    source ${CMD_DIR}/common-config
+fi
 source ${CMD_DIR}/build_helpers.sh
 
 do_oe_log()
@@ -132,7 +134,10 @@ XENCLIENT_TOOLS = "$XENCLIENT_TOOLS"
 
 # dir for generated deb packages
 XCT_DEB_PKGS_DIR := "${OE_BUILD_CACHE}/xct_deb_packages"
+EOF
 
+                if [ -f ${CMD_DIR}/common-config ]; then
+                    cat >> conf/local.conf <<EOF
 # xen version and source
 XEN_VERSION="${XEN_VERSION}"
 XEN_SRC_URI="${XEN_SRC_URI}"
@@ -140,6 +145,7 @@ XEN_SRC_MD5SUM="${XEN_SRC_MD5SUM}"
 XEN_SRC_SHA256SUM="${XEN_SRC_SHA256SUM}"
 
 EOF
+                fi
 
                 cat >> conf/local.conf <<EOF
 # Production and development repository-signing CA certificates

--- a/do_build.sh
+++ b/do_build.sh
@@ -32,7 +32,7 @@ export BUILD_UID
 
 # TODO: move some of the above definitions into common-config
 
-if [ -f ${CMD_DIR}/common-config ]
+if [ -f ${CMD_DIR}/common-config ]; then
     source ${CMD_DIR}/common-config
 fi
 source ${CMD_DIR}/build_helpers.sh

--- a/pkg-xctools/build.sh
+++ b/pkg-xctools/build.sh
@@ -62,33 +62,6 @@ make_bundle_xctools()
     mkdir -p ${deb_data}/lib/udev/rules.d
     ( cd ${BUILD_SCRIPTS}/pkg-xctools/udev-rules/ && cp *.rules ${deb_data}/lib/udev/rules.d/ )
 
-    # xenstore-tools
-    # TODO: That could be done much better.
-    local XST="xenstore-tools-xc"
-    local PDST_DIR="${deb_data}/usr/src/${XST}"
-    local XP="xen-${XEN_VERSION}"
-    rm -rf $PDST_DIR
-    mkdir -p $PDST_DIR
-    wget "${XEN_SRC_URI}" -O "${PDST_DIR}/xen.tar.gz"
-    pushd $PDST_DIR
-        tar xf xen.tar.gz
-        cd "${XP}"
-        touch config/Tools.mk
-        XEN_TARGET_ARCH=x86_64 make -C tools/include
-    popd
-    pushd "${deb_data}/usr/src/"
-    mkdir -p "t/tools"
-        cp -Lr "${XST}/${XP}/tools/include" "t/tools"
-        cp -Lr "${XST}/${XP}/tools/xenstore" "t/tools"
-        cp -Lr "${XST}/${XP}/config" "t"
-        cp -Lr "${XST}/${XP}/tools/Rules.mk" "t/tools"
-        cp -Lr "${XST}/${XP}/Config.mk" "t"
-        mv "${XST}" "${XST}.old"
-        mv "t" "${XST}"
-        rm -rf "${XST}.old"
-        find "${XST}" \( -name "*.py" -o -name "checker" \) -delete
-    popd
-
     # xenstore-agent
     mkdir -p git-tmp
     git_clone "git-tmp" "${OPENXT_GIT_PROTOCOL}://${OPENXT_GIT_MIRROR}/manager.git" "${BRANCH}" "$ALLOW_SWITCH_BRANCH_FAIL"

--- a/pkg-xctools/control/control
+++ b/pkg-xctools/control/control
@@ -5,7 +5,7 @@ Section: OpenXT
 License: GPLv2
 Installed-Size: @SIZE@
 Architecture: all
-Depends: dkms, make, linux-headers-2.6-686 | linux-headers-2.6-amd64 | linux-headers-generic | linux-headers | linux-headers-586 | linux-headers-686-pae | linux-headers-amd64, libc6 (>= 2.9), autoconf, pkg-config, gcc, libtool, zlib1g-dev, libx11-dev, libpciaccess-dev, pm-utils
+Depends: dkms, make, linux-headers-generic | linux-headers-586 | linux-headers-686-pae | linux-headers-amd64, libc6 (>= 2.9), autoconf, pkg-config, gcc, libtool, zlib1g-dev, libx11-dev, libpciaccess-dev, pm-utils, xenstore-utils
 Priority: optional
 Description: OpenXT in-guest tools.
  OpenXT Linux in-guest software.

--- a/pkg-xctools/control/postinst
+++ b/pkg-xctools/control/postinst
@@ -95,28 +95,6 @@ done
 modprobe xenfs
 
 #
-# Deals with xenstore-tools
-#
-NAME=xenstore-tools
-PACKAGE=${NAME}
-SRCS=/usr/src/${PACKAGE}-xc
-pushd ${SRCS}
-    echo "xenstore-tools building ..."
-    DESTDIR=/ CFLAGS='' LDFLAGS='' make -C tools/xenstore libxenstore.so
-    DESTDIR=/ CFLAGS='' LDFLAGS='' make -C tools/xenstore clients
-    ( cd tools/xenstore && cp -a libxenstore.so* "${LIBDIR}" )
-    ( cd tools/xenstore && cp xenstore.h xenstore_lib.h /usr/include )
-    ( cd tools/xenstore && cp -a xenstore xenstore-chmod xenstore-control xenstore-exists \
-       xenstore-list xenstore-ls xenstore-read xenstore-rm xenstore-watch xenstore-write /usr/bin/ )
-    tmp=`mktemp -d`
-    cp -r "/usr/include/xen" "${tmp}"
-    ( cd tools/include && cp -r xen /usr/include )
-    cp -r "${tmp}/xen/"* "/usr/include/xen"
-    rm -rf "${tmp}"
-    echo "xenstore-tools installed."
-popd
-
-#
 # Deals with libv4v
 #
 if [ -n "$HAS_V4V" ]; then


### PR DESCRIPTION
xen-common.inc is directly using these variables, it should be easier to
handle everything from the same place.

#### Required for:
- https://github.com/OpenXT/xenclient-oe/pull/1012