### PR TITLE
Ubuntu build support - setup script

### DIFF
--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -353,6 +353,12 @@ lxc.network.hwaddr = ${MAC_PREFIX}:${MAC_E}:${NUMBER}
 lxc.network.ipv4 = 0.0.0.0/24
 EOF
 
+    # Attempt a forward-port of the LXC container config
+    if [ ! -z $(which lxc-update-config) ] ; then
+      echo "Updating the ${NAME} container configuration file..."
+      lxc-update-config -c ${LXC_PATH}/${BUILD_USER}-${NAME}/config
+    fi
+
     local ROOTFS=${LXC_PATH}/${BUILD_USER}-${NAME}/rootfs
 
     echo "Configuring the ${NAME} container..."


### PR DESCRIPTION
Change the way Debian is identified to a more common approach (also works for RHEL and other distros). Also, lxc 3.0 doesn't like the legacy config options that are manually added by the setup tools, but seems to be happy after an lxc-update-config which saves a bit of work handling lxc versions manually.