### PR TITLE
OXT-1410: conf: Add seabios SRC_URI usual MIRROR

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -34,3 +34,9 @@ VIRTUAL-RUNTIME_keymaps = "xenclient-console-keymaps"
 
 # overwrite debian mirror for screen, as the debian version it's based on (lenny) is in oldstable now
 DEBIAN_MIRROR_pn-screen = "http://archive.debian.org/debian/pool"
+
+# Common URL translations.
+MIRRORS += " \
+    http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
+    http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
+"


### PR DESCRIPTION
This source has proven itself to be quite volatile. Provide default
convenience fallback to avoid frustration when building a clean tree.