### PR TITLE
debian install script: ensure current kernel headers are installed

### DIFF
--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -40,7 +40,7 @@ EOF
 
 echo "Installing the tools..."
 apt-get update
-apt-get -y --force-yes install $DKMS_PACKAGES $OTHER_PACKAGES
+apt-get -y --force-yes install linux-headers-$(uname -r) $DKMS_PACKAGES $OTHER_PACKAGES
 
 echo "Adding the new kernel modules to /etc/modules-load.d/openxt.conf"
 for package in `echo $DKMS_PACKAGES | sed 's/-dkms//g' | sed 's/openxt-xenmou/xenmou/'`; do


### PR DESCRIPTION
The kernel headers are automatically installed as a dkms dependency.
However, apt will install the headers for the latest kernel, which
  is not necessarily the current kernel, especially if the user
  didn't dist-upgrade as recommended.

Signed-off-by: Jed <lejosnej@ainfosec.com>