### PR TITLE
build-scripts: reverse build order

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -417,10 +417,10 @@ EOF
     rm -rf build-openxt
 }
 
-[ -z $NO_OE ]      && build_container "01" "oe"
-[ -z $NO_DEBIAN ]  && build_container "02" "debian"
-[ -z $NO_CENTOS ]  && build_container "03" "centos"
 [ -z $NO_WINDOWS ] && build_windows   "04"
+[ -z $NO_CENTOS ]  && build_container "03" "centos"
+[ -z $NO_DEBIAN ]  && build_container "02" "debian"
+[ -z $NO_OE ]      && build_container "01" "oe"
 
 build_tools_iso
 build_repository


### PR DESCRIPTION
OE takes 3 hours to build, Centos Debian and Windows each take about 5 minutes.
However, those last 3 are about as likely to fail as OE, maybe even more so for Windows.
In an attempt to fail as fast as possible, build:
- Windows first, that randomly breaks, especially around monthly updates
- Centos second, since the container tends to fail to start after builder reboots
- Debian third, less likely to break but really quick
- OE last, since it's the longest step

Signed-off-by: Jed <lejosnej@ainfosec.com>