### PR TITLE
STABLE-8: debian_install.sh: do not fail when /etc/debian_version doesn't exist

### DIFF
--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -11,7 +11,7 @@ DKMS_PACKAGES="v4v-dkms openxt-vusb-dkms openxt-xenmou-dkms"
 OTHER_PACKAGES="libv4v"
 
 DEBIAN_NAME=jessie
-DEBIAN_VERSION=`cut -d '.' -f 1 /etc/debian_version 2>/dev/null`
+DEBIAN_VERSION=`cut -d '.' -f 1 /etc/debian_version 2>/dev/null || true`
 [ "x$DEBIAN_VERSION" = "x7" ] && DEBIAN_NAME=wheezy
 
 echo "Removing old tools..."


### PR DESCRIPTION
Debian variants like Devuan may not have that file.

OXT-1470

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit b32d338c61bc6e6c5a3da0b00ac12ee1a73aab39)
Signed-off-by: Jed <lejosnej@ainfosec.com>