### PR TITLE
Stop using grubx64.efi symlink

### DIFF
--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -137,8 +137,9 @@ build_image() {
     fi
 
     # Transfer installer EFI files
-    if [ -f tmp-glibc/deploy/images/${MACHINE}/grubx64.efi ]; then
-        $RSYNC tmp-glibc/deploy/images/${MACHINE}/grubx64.efi ${TARGET}/raw/
+    if [ -f tmp-glibc/deploy/images/${MACHINE}/grub-efi-bootx64.efi ]; then
+        $RSYNC tmp-glibc/deploy/images/${MACHINE}/grub-efi-bootx64.efi \
+                ${TARGET}/raw/grubx64.efi
         $RSYNC tmp-glibc/deploy/images/${MACHINE}/isohdpfx.bin ${TARGET}/raw/
     fi
 }

--- a/do_build.sh
+++ b/do_build.sh
@@ -408,7 +408,8 @@ do_oe_installer_copy()
                 "$OUTPUT_DIR/$NAME/raw/installer/"
         cp "$binaries/$machine"/microcode_intel.bin \
                 "$OUTPUT_DIR/$NAME/raw/installer"
-        cp "$binaries/$machine/grubx64.efi" "$OUTPUT_DIR/$NAME/raw/"
+        cp "$binaries/$machine/grub-efi-bootx64.efi" \
+                "$OUTPUT_DIR/$NAME/raw/grubx64.efi"
         cp "$binaries/$machine/isohdpfx.bin" "$OUTPUT_DIR/$NAME/raw/"
 
         popd


### PR DESCRIPTION
grubx64.efi is a convenience symlink to grub-efi-bootx64.efi.
Unfortunately, it can get set to grub-efi-bootia32.efi if
grub-efi-native:do_deploy runs after grub-efi.  This breaks the build
with
cp: cannot stat ‘tmp-glibc/deploy/images/openxt-installer/grubx64.efi’: No such file or directory

Just copy the actual file and avoid the symlink.

OXT-1484

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

I tested the do_build code path, but I don't have a build-scripts setup to test that one.