### PR TITLE
meta-selinux: freeze layer to latest safe commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,7 @@
 	path = build/repos/meta-selinux
 	url = git://git.yoctoproject.org/meta-selinux
 	branch = master
+	update = none
 [submodule "build/repos/meta-intel"]
 	path = build/repos/meta-intel
 	url = git://git.yoctoproject.org/meta-intel


### PR DESCRIPTION
The meta-selinux layer doesn't have a pyro branch, so we were following master.
But master aligns with the OE/Yocto master branches, not pyro.
As master diverges, the probability of new changes breaking OpenXT increases.
This is what just happened.
This freezes the layer to prevent that from happening again.

Signed-off-by: Jed <lejosnej@ainfosec.com>