### PR TITLE
do_build.sh improvements

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -1436,6 +1436,8 @@ do_build()
                 eval "${name}_pid=$pid"
                 STEPNUM=`expr $STEPNUM + 1`
         done
+
+        echo "Finished $(date)"
 }
 
 

--- a/do_build.sh
+++ b/do_build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash -e
 set -o pipefail
 
-STEPS="setupoe,initramfs,stubinitramfs,dom0,uivm,ndvm,syncvm,sysroot,installer,installer2,syncui,source,sdk,license,sourceinfo,ship"
+STEPS="setupoe,initramfs,stubinitramfs,dom0,uivm,ndvm,syncvm,installer,installer2,syncui,source,sdk,license,sourceinfo,ship"
 
 # Additional steps:
 
@@ -363,19 +363,6 @@ do_oe_dom0()
         local path="$1"
         do_oe "$path" "xenclient-dom0" "xenclient-dom0-image"
         do_oe_dom0_copy $path
-}
-
-do_oe_sysroot_copy()
-{
-        local path="$1"
-        do_oe_copy "$path" "sysroot" "xenclient-sysroot" "xenclient-dom0"
-}
-
-do_oe_sysroot()
-{
-        local path="$1"
-        do_oe "$path" "xenclient-dom0" "xenclient-sysroot-image"
-        do_oe_sysroot_copy $path
 }
 
 do_oe_installer_copy()
@@ -1374,10 +1361,6 @@ do_build()
                                 do_oe_dom0 "$path" ;;
                         dom0cp)
                                 do_oe_dom0_copy "$path" ;;
-                        sysroot)
-                                do_oe_sysroot "$path" ;;
-                        sysrootcp)
-                                do_oe_sysroot_copy "$path" ;;
                         initramfs*)
                                 do_oe "$path" "xenclient-dom0" "xenclient-initramfs-image" ;;
                         stubinitramfs)

--- a/do_build.sh
+++ b/do_build.sh
@@ -1450,6 +1450,21 @@ sanitize_build_id() {
 
 BUILD_SCRIPTS="`pwd`/`dirname $0`"
 
+if [ -n "$CONFIG" ]; then
+        if [ -r "$CONFIG" ]; then
+                . "$CONFIG"
+        else
+                echo "Config file does not exist or could not be read: ${CONFIG}"
+                exit 1
+        fi
+else
+        if [ ! -f ".config" ]; then
+                echo ".config file is missing"
+                exit 1
+        fi
+        . .config
+fi
+
 while [ "$#" -ne 0 ]; do
         case "$1" in
                 -b) BRANCH="$2" ; shift 2 ;;
@@ -1467,20 +1482,5 @@ while [ "$#" -ne 0 ]; do
 done
 
 [ "x$DEBUG" != "x" ] && env >&2 && set -x
-
-if [ -n "$CONFIG" ]; then
-        if [ -r "$CONFIG" ]; then
-                . "$CONFIG"
-        else
-                echo "Config file does not exist or could not be read: ${CONFIG}"
-                exit 1
-        fi
-else
-        if [ ! -f ".config" ]; then
-                echo ".config file is missing"
-                exit 1
-        fi
-        . .config
-fi
 
 do_build


### PR DESCRIPTION
Drop sysroot from the script.  It's unneeded and unused as far as I can tell.  I usually drop syncui,source,sdk,license,sourceinfo as well, but I've left those.

Re-order sourcing the .config file before parsing the command line options.  This way you can set your common variables in .config and override on the command line.  The current way does not allow command line overriding.  For instance, you can set your default STEPS in .config, but then run just `./do_build.sh -s ndvm,ship` to do a quicker partial re-build.

Third, print the date when finished.  I find this useful when I have multiple windows open to know when a build last finished.