### PR TITLE
S9: OXT-1611: version: Allow upgrades from 8.0.0.

### DIFF
--- a/version
+++ b/version
@@ -17,4 +17,4 @@ XC_TOOLS_MINOR="0"
 XC_TOOLS_MICRO="0"
 
 # Space-separated list of previous releases that can be upgraded from
-UPGRADEABLE_RELEASES="8.0.1 8.0.2"
+UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2"


### PR DESCRIPTION
8.0.1 has been versioned 8.0.0.
Add upgrade path from the latest released version.