### PR TITLE
S9: build-scripts: linux install: skip the v4v packages

### DIFF
--- a/build-scripts/centos/install.sh
+++ b/build-scripts/centos/install.sh
@@ -5,8 +5,7 @@ set -e
 cd `dirname $0`
 
 VERSION=%VERSION%
-DKMS_PACKAGES="openxt-v4v openxt-vusb openxt-xenmou"
-OTHER_PACKAGES="libv4v"
+DKMS_PACKAGES="openxt-vusb openxt-xenmou"
 
 ARCH=`uname -i`
 
@@ -74,7 +73,7 @@ baseurl=file:///var/opt/openxt/rpms
 EOF
 
 echo "Installing the tools..."
-yum -y -t --nogpgcheck install $DKMS_PACKAGES $OTHER_PACKAGES
+yum -y -t --nogpgcheck install $DKMS_PACKAGES
 
 echo "Adding the new kernel modules to /etc/modules-load.d/openxt.conf"
 for package in `echo $DKMS_PACKAGES | sed 's/openxt-xenmou/xenmou/'`; do

--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -7,8 +7,7 @@ set -e
 cd `dirname $0`
 
 VERSION=%VERSION%
-DKMS_PACKAGES="v4v-dkms openxt-vusb-dkms openxt-xenmou-dkms"
-OTHER_PACKAGES="libv4v"
+DKMS_PACKAGES="openxt-vusb-dkms openxt-xenmou-dkms"
 
 DEBIAN_NAME=jessie
 DEBIAN_VERSION=`cut -d '.' -f 1 /etc/debian_version 2>/dev/null || true`
@@ -40,7 +39,7 @@ EOF
 
 echo "Installing the tools..."
 apt-get update
-apt-get -y --force-yes install linux-headers-$(uname -r) $DKMS_PACKAGES $OTHER_PACKAGES
+apt-get -y --force-yes install linux-headers-$(uname -r) $DKMS_PACKAGES
 
 mod_dir=/etc/modules-load.d
 mod_file=$mod_dir/openxt.conf


### PR DESCRIPTION
Build and ship them but don't install them by default, since OpenXT uses argo now.
They can still be installed manually with apt-get/yum if needed.

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit 2510add92751cbb99c1e74417a2a318293bb72ef)
Signed-off-by: Jed <lejosnej@ainfosec.com>