### PR TITLE
[debian] Temporary: Don't install xenmou driver

### DIFF
--- a/build-scripts/debian/install.sh
+++ b/build-scripts/debian/install.sh
@@ -7,7 +7,7 @@ set -e
 cd `dirname $0`
 
 VERSION=%VERSION%
-DKMS_PACKAGES="openxt-vusb-dkms openxt-xenmou-dkms"
+DKMS_PACKAGES="openxt-vusb-dkms"
 
 DEBIAN_NAME=jessie
 DEBIAN_VERSION=`cut -d '.' -f 1 /etc/debian_version 2>/dev/null || true`


### PR DESCRIPTION
The xenmou driver causes issues on Debian and Ubuntu
systems. Debian systems will boot without mouse
functionality and Ubuntu systems won't make it to the
login screen due to a dereferenced NULL pointer.

Note that this is a temporary bandaid and should be
fixed when possible.

OXT-1608

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>