### PR TITLE
OXT-1645: console-setup: Override mirror.

### DIFF
--- a/build/conf/local.conf-dist
+++ b/build/conf/local.conf-dist
@@ -34,6 +34,9 @@ VIRTUAL-RUNTIME_keymaps = "xenclient-console-keymaps"
 
 # overwrite debian mirror for screen, as the debian version it's based on (lenny) is in oldstable now
 DEBIAN_MIRROR_pn-screen = "http://archive.debian.org/debian/pool"
+# overwrite debian mirror for console 1.192. It is no longer in the main mirror
+# and not in archive.debian.org, raspbian provides an alternative.
+DEBIAN_MIRROR_pn-console-setup-ckbcomp-native = "http://sourcearchive.raspbian.org"
 
 # Common URL translations.
 MIRRORS += " \


### PR DESCRIPTION
The DEBIAN_MIRROR now provides 1.193 and removed 1.192.
Fetch from raspbian for now.

See [Build failure](http://openxt-builder.ainfosec.com:8010/builders/openxt64/builds/6682/steps/Build/logs/stdio)