### PR TITLE
version: Allow upgrade from upcoming release.

### DIFF
--- a/version
+++ b/version
@@ -17,4 +17,4 @@ XC_TOOLS_MINOR="0"
 XC_TOOLS_MICRO="0"
 
 # Space-separated list of previous releases that can be upgraded from
-UPGRADEABLE_RELEASES="9.0.0"
+UPGRADEABLE_RELEASES="9.0.1"


### PR DESCRIPTION
OpenXT policy is to allow upgrades from the last major, latest
micro-release. Replace 9.0.0 with 9.0.1.