### PR TITLE
S9: build-scripts: fetch.sh: keep going when a branch is missing

### DIFF
--- a/build-scripts/fetch.sh
+++ b/build-scripts/fetch.sh
@@ -34,7 +34,7 @@ for i in ${GIT_ROOT_PATH}/${BUILD_USER}/*.git; do
     echo -n "Fetching `basename $i`: "
     cd $i
     git fetch --all > /dev/null 2>&1
-    git show-ref -s $BRANCH
+    git show-ref -s $BRANCH || echo "BRANCH $BRANCH NOT FOUND"
     cd - > /dev/null
 done | tee /tmp/git_heads_$BUILD_USER
 


### PR DESCRIPTION
All the OpenXT repositories are mirrored in /home/git, but some may
not have the branch we're currently building, which is usually ok.
Log the missing branch and keep going instead of erroring out.

Signed-off-by: Jed <lejosnej@ainfosec.com>
(cherry picked from commit 36083e1b7191548d05106575eebf0a940de107ba)
Signed-off-by: Jed <lejosnej@ainfosec.com>