### PR TITLE
Fix Windows build machine setup on recent versions

### DIFF
--- a/build-scripts/windows/setup.sh
+++ b/build-scripts/windows/setup.sh
@@ -79,9 +79,10 @@ apt-get install qemu-kvm virtinst
 
 virt-install \
     --virt-type kvm \
+    --boot hd,cdrom \
     --name ${vm_name} \
     --memory 2048 \
-    --disk /home/${BUILD_USER}/windows/${disk_pool}/disk,bus=virtio,size=80 \
+    --disk /home/${BUILD_USER}/windows/${disk_pool}/disk,format=raw,bus=virtio,size=80 \
     --disk /home/${BUILD_USER}/windows/win.iso,device=cdrom,bus=ide \
     --disk /home/${BUILD_USER}/windows/tools.iso,device=cdrom,bus=ide \
     -w bridge=${BUILD_USER}br0,mac=${MAC_ADDR},model=virtio \

--- a/windows/mkbuildserver.ps1
+++ b/windows/mkbuildserver.ps1
@@ -67,7 +67,7 @@ copy BuildDaemon\winbuildd.bat "$($startup)\winbuildd.bat"
 # Create ssh key
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
 cd C:\winbuildd
-ssh-keygen -t rsa -N "''" -f id_rsa
+ssh-keygen -t rsa -N '""' -f id_rsa
 
 # Done
 Write-Host "Done. Please reboot one last time."


### PR DESCRIPTION
virt-install is now (as of Debian Buster) stricter about VM options.
Added the missing params to make it happy.
Also the latest Windows 10 rejects "''" for the empty string argument
of ssh-keygen, and expects '""' instead, which actually makes sense.

Signed-off-by: Jed <lejosnej@ainfosec.com>