### PR TITLE
build-scripts: setup.sh: Update the OE container to Debian Buster

### DIFF
--- a/build-scripts/oe/setup.sh
+++ b/build-scripts/oe/setup.sh
@@ -32,7 +32,7 @@ sed -i '/^start)$/a        mkdir -p /dev/shm/network/' /etc/init.d/networking
 PKGS=""
 PKGS="$PKGS openssh-server openssl"
 PKGS="$PKGS sed wget cvs subversion git-core coreutils unzip texi2html texinfo docbook-utils gawk python-pysqlite2 diffstat help2man make gcc build-essential g++ desktop-file-utils chrpath cpio screen bash-completion python3 iputils-ping" # OE main deps
-PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev libc6-dev-i386 libelf-dev" # OpenXT-specific deps
+PKGS="$PKGS guilt iasl quilt bin86 bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim sudo rpm curl libncurses5-dev libncursesw5 libc6-dev-i386 libelf-dev" # OpenXT-specific deps
 PKGS="$PKGS xorriso mtools dosfstools" # installer & efiboot.img
 
 apt-get update

--- a/build-scripts/setup.sh
+++ b/build-scripts/setup.sh
@@ -446,7 +446,7 @@ EOF
 
 # Create a container for the main part of the OpenXT build
 [ -z $NO_OE ] && setup_container "01" "oe" \
-                "debian" "${DEBIAN_MIRROR}" "--arch amd64  --release jessie"
+                "debian" "${DEBIAN_MIRROR}" "--arch amd64  --release buster"
 
 # Create a container for the Debian tool packages for OpenXT
 [ -z $NO_DEBIAN ] && setup_container "02" "debian" \


### PR DESCRIPTION
Also add explicit install of libncursesw5, which doesn't seem to
get pulled automatically anymore in Buster.

Signed-off-by: Jed <lejosnej@ainfosec.com>