### PR TITLE
modules: Track meta-java zeus branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "build/repos/meta-java"]
 	path = build/repos/meta-java
 	url = git://git.yoctoproject.org/meta-java
-	branch = master
+	branch = zeus
 [submodule "build/repos/meta-openembedded"]
 	path = build/repos/meta-openembedded
 	url = git://git.openembedded.org/meta-openembedded


### PR DESCRIPTION
OpenXT master currently aligns on Zeus.
meta-java provides a zeus branch, so it should be tracked instead of
master.

OpenXT master builds are currently broken as `meta-java` `master` is no longer compatible with `zeus` since, at least,  `openembedded-core/meta/classes/distro_features_check.bbclass` is deprecated in favor of `openembedded-core/meta/classes/features_check.bbclass`.