### PR TITLE
build: handle do_deploy refactoring

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -339,7 +339,7 @@ build_iso() {
     rm -rf iso_tmp
     mkdir -p iso_tmp/isolinux
     cp -rf netboot/* iso_tmp/isolinux/
-    cp -rf installer/iso/* iso_tmp/isolinux/
+    cp -rf iso/* iso_tmp/isolinux/
     ln -s ../repository/packages.main iso_tmp/packages.main
     # If we already ran build_finalize(), netboot has a copy of rootfs.gz.
     # Since netboot/* was just copied into iso_tmp/isolinux, we'd now have it.
@@ -400,7 +400,6 @@ EOF
     tar -C "repository" -cf "update/update.tar" packages.main
 
     # Copy all the netboot files to the netboot directory and tar it up
-    cp installer/netboot/* netboot/
     cp raw/installer-rootfs.cpio.gz netboot/rootfs.gz
     rm -f netboot/netboot.tar.gz
     tar -C netboot -czf netboot.tar.gz .

--- a/build-scripts/oe/build.sh
+++ b/build-scripts/oe/build.sh
@@ -104,7 +104,6 @@ build_image() {
     SOURCE_BASE=tmp-glibc/deploy/images/${MACHINE}/${IMAGE_NAME}-image
     SOURCE_IMAGE=${SOURCE_BASE}-${MACHINE}.${EXTENSION}
     SOURCE_LICENSES=${SOURCE_BASE}-licences.csv
-    SOURCE_EXTRAS=${SOURCE_BASE}-${MACHINE}
     TARGET=${BUILD_USER}@${HOST_IP}:${ALL_BUILDS_SUBDIR_NAME}/${BUILD_DIR}/
 
     # Transfer image and give it the expected name
@@ -131,9 +130,12 @@ build_image() {
         $RSYNC ${SOURCE_LICENSES} ${TARGET}/licenses/
     fi
 
-    # Transfer additionnal files
-    if [ -d ${SOURCE_EXTRAS} ]; then
-        $RSYNC ${SOURCE_EXTRAS}/ ${TARGET}/${REAL_NAME}
+    # Transfer files to be deployed on install media.
+    if [ -d tmp-glibc/deploy/images/${MACHINE}/iso ]; then
+        $RSYNC tmp-glibc/deploy/images/${MACHINE}/iso ${TARGET}
+    fi
+    if [ -d tmp-glibc/deploy/images/${MACHINE}/netboot ]; then
+        $RSYNC tmp-glibc/deploy/images/${MACHINE}/netboot ${TARGET}
     fi
 
     # Transfer installer EFI files


### PR DESCRIPTION
With the removal of IMAGE_POSTPROCESS_COMMAND for xenclient-installer-image, the ISO and PXE files end up in slightly different directories.
The postprocess commands were able to use IMAGE_LINK_NAME to create a subdirectory, which is not possible in do_deploy.

#### Require:
- https://github.com/OpenXT/xenclient-oe/pull/1341