### PR TITLE
do_build.sh: Grab deployed artifacts

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -378,10 +378,10 @@ do_oe_installer_copy()
 
         # Copy extra installer files
         rm -rf "$OUTPUT_DIR/$NAME/raw/installer/iso"
-        cp -r "$binaries/$machine/xenclient-installer-image-$machine/iso" \
+        cp -r "$binaries/$machine/iso" \
                 "$OUTPUT_DIR/$NAME/raw/installer/iso"
         rm -rf "$OUTPUT_DIR/$NAME/raw/installer/netboot"
-        cp -r "$binaries/$machine/xenclient-installer-image-$machine/netboot" \
+        cp -r "$binaries/$machine/netboot" \
                 "$OUTPUT_DIR/$NAME/raw/installer/netboot"
         cp "$binaries/$machine/bzImage-$machine.bin" \
                 "$OUTPUT_DIR/$NAME/raw/installer/vmlinuz"


### PR DESCRIPTION
This updates do_build.sh to grab artifacts from the new location used by
the do_deploy task.

This is the change to do_build.sh needed for https://github.com/OpenXT/xenclient-oe/pull/1341