### PR TITLE
setup_build: Use bash shebang

### DIFF
--- a/setup_build
+++ b/setup_build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # OpenXT git repo setup file.
 
 die() {


### PR DESCRIPTION
`local git=${!git_var}` is a bash-ism, so specify bash as the
interpreter.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>