### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+UNMAINTAINED!!!  Please use [bordel](https://github.com/OpenXT/bordel)
+
+This build system only supports stable-9 and earlier.  For xenclient-oe.git as
+of [the merging of vGlass](https://github.com/OpenXT/xenclient-oe/commit/8522fd8c43d57c33cece73a26b4c7498f3d8a58d), see
+[bordel](https://github.com/OpenXT/bordel)
 
 See [the OpenXT wiki](https://github.com/openxt/openxt/wiki) for more
 information. Specifically, see the [How to build OpenXT


### PR DESCRIPTION
This repo is no longer set up to build OpenXT master after the vGlass
merging.  Point people at bordel since that is used and can build
OpenXT with vGlass.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>